### PR TITLE
[modal] modal 템플릿 생성

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,6 +44,7 @@
     />
   </head>
   <body>
+    <div id="modal"></div>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import Modal from '@components/Modal';
 import { Global, ThemeProvider } from '@emotion/react';
+import useModal from '@hooks/useModal';
 import { RouterProvider } from 'react-router-dom';
 
 import globalStyles from './common/styles/globalStyles';
@@ -7,11 +8,19 @@ import { theme } from './common/styles/theme';
 import router from './Router';
 
 const App = () => {
+  const { modalRef, handleShowModal } = useModal();
+
   return (
     <ThemeProvider theme={theme}>
       <Global styles={globalStyles} />
       <RouterProvider router={router} />
-      <Modal />
+      <button onClick={handleShowModal}>CLICK ME!!!</button>
+      <Modal ref={modalRef}>
+        <p>Modal</p>
+        <form method="dialog">
+          <button>123</button>
+        </form>
+      </Modal>
     </ThemeProvider>
   );
 };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,4 @@
+import Modal from '@components/Modal';
 import { Global, ThemeProvider } from '@emotion/react';
 import { RouterProvider } from 'react-router-dom';
 
@@ -10,6 +11,7 @@ const App = () => {
     <ThemeProvider theme={theme}>
       <Global styles={globalStyles} />
       <RouterProvider router={router} />
+      <Modal />
     </ThemeProvider>
   );
 };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,11 +14,13 @@ const App = () => {
     <ThemeProvider theme={theme}>
       <Global styles={globalStyles} />
       <RouterProvider router={router} />
-      <button onClick={handleShowModal}>CLICK ME!!!</button>
+      <button style={{ color: 'red' }} onClick={handleShowModal}>
+        CLICK ME!!!
+      </button>
       <Modal ref={modalRef}>
         <p>Modal</p>
         <form method="dialog">
-          <button>123</button>
+          <button style={{ color: 'red' }}>CLOSE ME</button>
         </form>
       </Modal>
     </ThemeProvider>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,4 @@
-import Modal from '@components/Modal';
 import { Global, ThemeProvider } from '@emotion/react';
-import useModal from '@hooks/useModal';
 import { RouterProvider } from 'react-router-dom';
 
 import globalStyles from './common/styles/globalStyles';
@@ -8,21 +6,10 @@ import { theme } from './common/styles/theme';
 import router from './Router';
 
 const App = () => {
-  const { modalRef, handleShowModal } = useModal();
-
   return (
     <ThemeProvider theme={theme}>
       <Global styles={globalStyles} />
       <RouterProvider router={router} />
-      <button style={{ color: 'red' }} onClick={handleShowModal}>
-        CLICK ME!!!
-      </button>
-      <Modal ref={modalRef}>
-        <p>Modal</p>
-        <form method="dialog">
-          <button style={{ color: 'red' }}>CLOSE ME</button>
-        </form>
-      </Modal>
     </ThemeProvider>
   );
 };

--- a/src/common/components/Modal/index.tsx
+++ b/src/common/components/Modal/index.tsx
@@ -3,6 +3,14 @@ import styled from '@emotion/styled';
 import { forwardRef, PropsWithChildren } from 'react';
 import { createPortal } from 'react-dom';
 
+/**
+ * modal component :
+ * 1. children으로 code 넘기기.
+ * 2. close button은
+ * `<form method="dialog">`
+ * 태그로 감싸주면
+ * 별다른 로직 없이 close 기능 구현 가능합니다.
+ */
 const Modal = forwardRef<HTMLDialogElement, PropsWithChildren>(({ children }, ref) => {
   return createPortal(
     <ModalDialog ref={ref}>{children}</ModalDialog>,

--- a/src/common/components/Modal/index.tsx
+++ b/src/common/components/Modal/index.tsx
@@ -1,14 +1,16 @@
 import { keyframes } from '@emotion/react';
 import styled from '@emotion/styled';
-import { PropsWithChildren } from 'react';
+import { forwardRef, PropsWithChildren } from 'react';
 import { createPortal } from 'react-dom';
 
-const Modal = ({ children }: PropsWithChildren) => {
+const Modal = forwardRef<HTMLDialogElement, PropsWithChildren>(({ children }, ref) => {
   return createPortal(
-    <ModalDialog open>{children}</ModalDialog>,
+    <ModalDialog ref={ref}>{children}</ModalDialog>,
     document.getElementById('modal')!,
   );
-};
+});
+
+Modal.displayName = 'Modal';
 
 export default Modal;
 

--- a/src/common/components/Modal/index.tsx
+++ b/src/common/components/Modal/index.tsx
@@ -1,15 +1,46 @@
+import { keyframes } from '@emotion/react';
+import styled from '@emotion/styled';
+import { PropsWithChildren } from 'react';
 import { createPortal } from 'react-dom';
 
-const Modal = () => {
+const Modal = ({ children }: PropsWithChildren) => {
   return createPortal(
-    <dialog open>
-      <p>Modal</p>
-      <form method="dialog">
-        <button>123</button>
-      </form>
-    </dialog>,
+    <ModalDialog open>{children}</ModalDialog>,
     document.getElementById('modal')!,
   );
 };
 
 export default Modal;
+
+const slideInFromTop = keyframes`
+0% {
+  transform: translate(-50%, -65%);
+  opacity: 0;
+}
+100% {
+  transform: translate(-50%, -50%);
+  opacity: 1;
+}
+`;
+
+const ModalDialog = styled.dialog`
+  position: fixed;
+  top: 50vh;
+  left: 50%;
+  width: 47.6rem;
+  height: 47.6rem;
+  padding: 2rem;
+  color: ${({ theme }) => theme.colors.gray_000};
+  background: ${({ theme }) => theme.colors.gray_550};
+  border: none;
+  border-radius: 10px;
+  transform: translate(-50%, -50%);
+
+  &[open] {
+    animation: ${slideInFromTop} 0.35s ease-out;
+  }
+
+  &::backdrop {
+    background: ${({ theme }) => theme.colors.background};
+  }
+`;

--- a/src/common/components/Modal/index.tsx
+++ b/src/common/components/Modal/index.tsx
@@ -1,0 +1,15 @@
+import { createPortal } from 'react-dom';
+
+const Modal = () => {
+  return createPortal(
+    <dialog open>
+      <p>Modal</p>
+      <form method="dialog">
+        <button>123</button>
+      </form>
+    </dialog>,
+    document.getElementById('modal')!,
+  );
+};
+
+export default Modal;

--- a/src/common/hooks/useModal.tsx
+++ b/src/common/hooks/useModal.tsx
@@ -1,5 +1,13 @@
 import { useRef } from 'react';
 
+/**
+ * 사용법 :
+ * 원하는 component 내에서
+ * const { modalRef, handleShowModal } = useModal();
+ * 받아온 후,
+ * `<Modal ref={modalRef}>`
+ * Modal에 ref로 넣어주세요.
+ */
 const useModal = () => {
   const modalRef = useRef<HTMLDialogElement | null>(null);
 

--- a/src/common/hooks/useModal.tsx
+++ b/src/common/hooks/useModal.tsx
@@ -7,6 +7,13 @@ const useModal = () => {
     modalRef.current?.showModal();
   };
 
+  // esc키 눌렀을 때 모달창 닫히는 거 막기
+  document.addEventListener('keydown', (e) => {
+    if (e.code === 'Escape') {
+      e.preventDefault();
+    }
+  });
+
   return { modalRef, handleShowModal };
 };
 

--- a/src/common/hooks/useModal.tsx
+++ b/src/common/hooks/useModal.tsx
@@ -1,0 +1,13 @@
+import { useRef } from 'react';
+
+const useModal = () => {
+  const modalRef = useRef<HTMLDialogElement | null>(null);
+
+  const handleShowModal = () => {
+    modalRef.current?.showModal();
+  };
+
+  return { modalRef, handleShowModal };
+};
+
+export default useModal;


### PR DESCRIPTION
## 🔥 Related Issues

- close #66 

## 💜 작업 내용

- [x] modal 기초적인 UI 구현
- [x] 확인, 취소 버튼 외의 모든 마우스 및 키보드 이벤트 prevent
- [x] custom hook 만들기

## ✅ PR Point

dialog를 새로 도입해 봤는데 좀 어렵네요

### modal 사용법
```typescript
const App = () => {
  const { modalRef, handleShowModal } = useModal();

  return (
      <button onClick={handleShowModal}>CLICK ME!!!</button>
      <Modal ref={modalRef}>
        <p>Modal</p>
        <form method="dialog">
          <button>CLOSE ME</button>
        </form>
      </Modal>
  );
};
```

사용 원하는 컴포넌트 내에서
`const { modalRef, handleShowModal } = useModal();`
custom hook을 이용하여 ref 가져온 후,

click시 modal창이 떴으면 하는 곳에
`<button onClick={handleShowModal}>CLICK ME!!!</button>`
handleShowModal 넣어주고

click시 modal창이 없어졌으면 하는 곳에
```
<form method="dialog">
  <button>CLOSE ME</button>
</form>
```
form 태그로 button 감싸준 뒤, method="dialog" 추가해주면 됩니다.
`주의할 점 : type="button"을 추가해주면 안 됩니다!! form -> submit으로 작동하는 거라 type 추가하실 필요 없어요`

<br /><br /><br />

<img width="704" alt="스크린샷 2024-01-10 오후 10 28 07" src="https://github.com/MOONSHOT-Team/MOONSHOT-CLIENT/assets/121864459/0158787e-a23e-4edb-88b7-de5df2627661">

저희 이 모달도 있는데 이건 modal component 이용하지 않고 그냥 따로 컴포넌트 만들어서 사용해도 될 거 같아 고려하지 않았습니다.

하지만 이건 제 개인적인 생각이고

width랑 height default value를 위의 큰 모달 기준으로 잡고, 작은 모달창 만들 때 선택적으로 width={158} height={80} 이런 식으로 넘길 수 있는데

그냥 이 작은 모달은 컴포넌트 따로 만들기 vs width 동적으로 주어 작은 모달창도 Modal.tsx를 이용하여 만들기

이 두 개 중 어떤게 더 좋은 거 같나요?

## ☀️ 스크린샷 / GIF / 화면 녹화
<img width="706" alt="스크린샷 2024-01-10 오후 10 18 30" src="https://github.com/MOONSHOT-Team/MOONSHOT-CLIENT/assets/121864459/9d1c0c96-2a71-4333-a4ac-ff7dfbc3b9ae">
