### PR TITLE
[SP1/Refactor] addOkr  ~ previewOkr QA 사항 반영

### DIFF
--- a/src/AddOkr/components/addKr/GuideFirstKeyResultCard.tsx
+++ b/src/AddOkr/components/addKr/GuideFirstKeyResultCard.tsx
@@ -3,7 +3,7 @@ import { Dayjs } from 'dayjs';
 import { useEffect, useState } from 'react';
 
 import { IcClose } from '../../assets/icons';
-import { MAX_KR_TITLE } from '../../constants/MAX_KR_LENGTH';
+import { MAX_KR_TITLE } from '../../constants/OKR_MAX_LENGTH';
 import { CloseIconStyle, EmptyKeyResultCard } from '../../styles/KeyResultCardStyle';
 import { IKrListInfoTypes } from '../../types/KrInfoTypes';
 import { IObjInfoTypes } from '../../types/ObjectInfoTypes';

--- a/src/AddOkr/components/addKr/GuideSecondKeyResultCard.tsx
+++ b/src/AddOkr/components/addKr/GuideSecondKeyResultCard.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { useState } from 'react';
 
-import { MAX_KR_METRIC, MAX_KR_TARGET } from '../../constants/MAX_KR_LENGTH';
+import { MAX_KR_METRIC, MAX_KR_TARGET } from '../../constants/OKR_MAX_LENGTH';
 import { EmptyKeyResultCard } from '../../styles/KeyResultCardStyle';
 import { IKrListInfoTypes } from '../../types/KrInfoTypes';
 

--- a/src/AddOkr/components/addKr/KeyResultCard.tsx
+++ b/src/AddOkr/components/addKr/KeyResultCard.tsx
@@ -1,9 +1,8 @@
 import styled from '@emotion/styled';
 import { Dayjs } from 'dayjs';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import { IcClose } from '../../assets/icons';
-import { CALE_END_DATE, CALE_START_DATE } from '../../constants/ADD_OKR_DATES';
 import { MAX_KR_METRIC, MAX_KR_TARGET, MAX_KR_TITLE } from '../../constants/MAX_KR_LENGTH';
 import { CloseIconStyle, EmptyKeyResultCard } from '../../styles/KeyResultCardStyle';
 import { IKrListInfoTypes } from '../../types/KrInfoTypes';
@@ -35,7 +34,8 @@ const KeyResultCard = ({
     target: false,
     metric: false,
   });
-  const { title, target, metric } = krListInfo[cardIdx];
+  const { title, target, metric, startAt: krStartAt, expireAt: krExpireAt } = krListInfo[cardIdx];
+  const { objStartAt, objExpireAt } = objInfo;
 
   /** 
   캘린더 관련 요소
@@ -43,7 +43,34 @@ const KeyResultCard = ({
   //캘린더 보여주는 플래그
   const [isShowCalender, setIsShowCalender] = useState(false);
   //캘린더 선택한 값
-  const [krPeriod, setKrPeriod] = useState([CALE_START_DATE, CALE_END_DATE]);
+  // const [krPeriod, setKrPeriod] = useState([
+  //   krStartAt ? krStartAt : '',
+  //   krExpireAt ? krExpireAt : '',
+  // ]);
+
+  useEffect(() => {
+    // kr 선택 예외 처리) 날짜 기간을 입력 했으나, 앞에서 obj 기간을 수정한 경우 obj 기간으로 초기화
+    if (new Date(objStartAt) > new Date(krStartAt) || new Date(objExpireAt) < new Date(krExpireAt))
+      krListInfo[cardIdx] = {
+        ...krListInfo[cardIdx],
+        startAt: objStartAt,
+        expireAt: objExpireAt,
+      };
+    setKrListInfo([...krListInfo]);
+  }, []);
+
+  const handleClickKrPeriodBox = () => {
+    // 날짜 기간을 입력한 경우 이벤트 전파 방지
+    if (isShowCalender) return;
+
+    krListInfo[cardIdx] = {
+      ...krListInfo[cardIdx],
+      startAt: objStartAt,
+      expireAt: objExpireAt,
+    };
+    setKrListInfo([...krListInfo]);
+    setIsShowCalender(true);
+  };
 
   const handleChangeBasicKr = (e: React.ChangeEvent<HTMLInputElement>, maxLength: number) => {
     const parsedValue = e.target.value.replace(/[^-0-9]/g, '');
@@ -78,7 +105,7 @@ const KeyResultCard = ({
     formatString: [string, string],
   ) => {
     if (formatString[0] && formatString[1]) {
-      setKrPeriod(formatString);
+      // setKrPeriod(formatString);
       krListInfo[cardIdx] = {
         ...krListInfo[cardIdx],
         startAt: formatString[0],
@@ -144,11 +171,11 @@ const KeyResultCard = ({
       {/*달성 기간 입력 부분*/}
       <StKrInputDescWrapper>
         <StKrInputDescription>핵심 지표를 달성할 기간을 입력해주세요</StKrInputDescription>
-        <StKrPeriodBox onClick={() => setIsShowCalender(true)} $isHoverStyle={isShowCalender}>
-          {isShowCalender ? (
+        <StKrPeriodBox onClick={handleClickKrPeriodBox}>
+          {isShowCalender || krStartAt || krExpireAt ? (
             <KeyResultPeriodInput
               handleClickSelectDate={handleClickSelectDate}
-              period={krPeriod}
+              krPeriod={[krStartAt, krExpireAt]}
               objInfo={objInfo}
             />
           ) : (
@@ -226,7 +253,7 @@ const StTargetMetricInput = styled.input<{ $isMax: boolean }>`
   }
 `;
 
-const StKrPeriodBox = styled.div<{ $isHoverStyle: boolean }>`
+const StKrPeriodBox = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
@@ -235,10 +262,13 @@ const StKrPeriodBox = styled.div<{ $isHoverStyle: boolean }>`
   padding: 0.6rem 0;
   color: ${({ theme }) => theme.colors.gray_400};
   text-align: center;
-  background-color: ${({ theme, $isHoverStyle }) =>
-    $isHoverStyle ? theme.colors.gray_550 : theme.colors.gray_600};
+  background-color: ${({ theme }) => theme.colors.gray_600};
   border: 1px solid ${({ theme }) => theme.colors.gray_500};
   border-radius: 6px;
 
   ${({ theme }) => theme.fonts.body_13_medium};
+
+  &:hover {
+    background-color: ${({ theme }) => theme.colors.gray_550};
+  }
 `;

--- a/src/AddOkr/components/addKr/KeyResultCard.tsx
+++ b/src/AddOkr/components/addKr/KeyResultCard.tsx
@@ -42,11 +42,6 @@ const KeyResultCard = ({
   **/
   //캘린더 보여주는 플래그
   const [isShowCalender, setIsShowCalender] = useState(false);
-  //캘린더 선택한 값
-  // const [krPeriod, setKrPeriod] = useState([
-  //   krStartAt ? krStartAt : '',
-  //   krExpireAt ? krExpireAt : '',
-  // ]);
 
   useEffect(() => {
     // kr 선택 예외 처리) 날짜 기간을 입력 했으나, 앞에서 obj 기간을 수정한 경우 obj 기간으로 초기화
@@ -105,7 +100,6 @@ const KeyResultCard = ({
     formatString: [string, string],
   ) => {
     if (formatString[0] && formatString[1]) {
-      // setKrPeriod(formatString);
       krListInfo[cardIdx] = {
         ...krListInfo[cardIdx],
         startAt: formatString[0],

--- a/src/AddOkr/components/addKr/KeyResultCard.tsx
+++ b/src/AddOkr/components/addKr/KeyResultCard.tsx
@@ -3,7 +3,7 @@ import { Dayjs } from 'dayjs';
 import React, { useEffect, useState } from 'react';
 
 import { IcClose } from '../../assets/icons';
-import { MAX_KR_METRIC, MAX_KR_TARGET, MAX_KR_TITLE } from '../../constants/MAX_KR_LENGTH';
+import { MAX_KR_METRIC, MAX_KR_TARGET, MAX_KR_TITLE } from '../../constants/OKR_MAX_LENGTH';
 import { CloseIconStyle, EmptyKeyResultCard } from '../../styles/KeyResultCardStyle';
 import { IKrListInfoTypes } from '../../types/KrInfoTypes';
 import { IObjInfoTypes } from '../../types/ObjectInfoTypes';

--- a/src/AddOkr/components/addKr/KeyResultPeriodInput.tsx
+++ b/src/AddOkr/components/addKr/KeyResultPeriodInput.tsx
@@ -12,13 +12,13 @@ interface IKeyResultPeriodInputProps {
     _values: [Dayjs | null, Dayjs | null] | null,
     formatString: [string, string],
   ) => void;
-  period: string[];
+  krPeriod: string[];
   objInfo: IObjInfoTypes;
 }
 
 const KeyResultPeriodInput = ({
   handleClickSelectDate,
-  period,
+  krPeriod,
   objInfo,
 }: IKeyResultPeriodInputProps) => {
   const { objStartAt, objExpireAt } = objInfo;
@@ -30,7 +30,7 @@ const KeyResultPeriodInput = ({
 
   const disabledDate: RangePickerProps['disabledDate'] = (current) => {
     return (
-      current < dayjs(objStartAt.split('. ').join('')).endOf('day') ||
+      current < dayjs(objStartAt.split('. ').join('')) ||
       current > dayjs(objExpireAt.split('. ').join('')).startOf('day')
     );
   };
@@ -56,7 +56,7 @@ const KeyResultPeriodInput = ({
         <RangePicker
           variant="borderless"
           onChange={handleClickSelectDate}
-          value={[dayjs(formatDate(period[0])), dayjs(formatDate(period[1]))]}
+          value={[dayjs(formatDate(krPeriod[0])), dayjs(formatDate(krPeriod[1]))]}
           defaultValue={[dayjs(), dayjs()]}
           format={'YYYY. MM. DD'}
           disabledDate={disabledDate}

--- a/src/AddOkr/components/addKr/KeyResultPeriodInput.tsx
+++ b/src/AddOkr/components/addKr/KeyResultPeriodInput.tsx
@@ -79,7 +79,7 @@ const StKRPeriodContainer = styled.div`
   }
 
   .ant-picker-input > input {
-    width: 7rem;
+    width: 8rem;
     color: ${({ theme }) => theme.colors.gray_000};
     border: none;
     ${({ theme }) => theme.fonts.body_12_regular};

--- a/src/AddOkr/components/objPeriod/PeriodSelectInput.tsx
+++ b/src/AddOkr/components/objPeriod/PeriodSelectInput.tsx
@@ -67,7 +67,7 @@ const StKRPeriodContainer = styled.div`
   }
 
   .ant-picker-input > input {
-    width: 7rem;
+    width: 8rem;
     color: ${({ theme }) => theme.colors.gray_000};
     border: none;
     ${({ theme }) => theme.fonts.body_12_regular};

--- a/src/AddOkr/components/stepLayout/AddGuideFirstKr.tsx
+++ b/src/AddOkr/components/stepLayout/AddGuideFirstKr.tsx
@@ -2,34 +2,38 @@ import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import React from 'react';
 
-import { AddOkrCardWrapper, EmptyKeyResultCard } from '../../styles/KeyResultCardStyle';
+import { AddOkrCardWrapper } from '../../styles/KeyResultCardStyle';
 import { IAddKrFlowProps } from '../../types/KrInfoTypes';
 import GuideFirstKeyResultCard from '../addKr/GuideFirstKeyResultCard';
-import GuideSecondKeyResultCard from '../addKr/GuideSecondKeyResultCard';
 import KeyResultPlusCard from '../addKr/KeyResultPlusCard';
-
-interface IAddGuideKrProps extends IAddKrFlowProps {
-  isActiveSecondKrCard: boolean;
-}
 
 const MAX_KR_LENGTH = 3;
 
-const AddGuideKr = ({
+const AddGuideFirstKr = ({
   objInfo,
   clickedCard,
   handleClickPlusCard,
   handleClickCloseBtn,
   krListInfo,
   setKrListInfo,
-  isActiveSecondKrCard,
-}: IAddGuideKrProps) => {
+}: IAddKrFlowProps) => {
   const { objTitle } = objInfo;
 
-  const renderFirstKrCards = () => {
-    const plusCardLength = Array.from({ length: MAX_KR_LENGTH - 1 }, (_, i) => i + 1);
+  const plusCardLength = Array.from({ length: MAX_KR_LENGTH - 1 }, (_, i) => i + 1);
 
-    return (
-      <>
+  return (
+    <section css={AddGuideKrContainer}>
+      <StFirstAddGuideKrTxt>
+        {
+          '목표를 이루기 위한 측정 가능한 이정표를 설정해볼거예요\n먼저, 목표를 달성하기 위해 어떤 성과들이 필요할까요?'
+        }
+      </StFirstAddGuideKrTxt>
+
+      <StObjTitleBox>
+        <p>{objTitle}</p>
+      </StObjTitleBox>
+
+      <AddOkrCardWrapper>
         <GuideFirstKeyResultCard
           cardIdx={0}
           objInfo={objInfo}
@@ -61,62 +65,12 @@ const AddGuideKr = ({
             </React.Fragment>
           );
         })}
-      </>
-    );
-  };
-
-  const renderSecondKrCards = () => {
-    const secondKrList = [0, 1, 2];
-
-    return (
-      <>
-        {secondKrList.map((indexOfCard) => {
-          return clickedCard.includes(indexOfCard) ? (
-            <GuideSecondKeyResultCard
-              key={indexOfCard}
-              cardIdx={indexOfCard}
-              krListInfo={krListInfo}
-              setKrListInfo={setKrListInfo}
-            />
-          ) : (
-            <EmptyKeyResultCard key={indexOfCard} />
-          );
-        })}
-      </>
-    );
-  };
-
-  return (
-    <section css={AddGuideKrContainer}>
-      {isActiveSecondKrCard ? (
-        <>
-          <StSecondAddGuideKrTxt>
-            {'달에 탐사선을 쏘아올릴 마음으로, 목표를 측정할 수 있는 핵심 지표를 설정해주세요'}
-          </StSecondAddGuideKrTxt>
-          <StSubGuideTxt>
-            moonshot에서 설정되는 목표 값은 70%에 도달할 시 완료로 간주되어요
-          </StSubGuideTxt>
-        </>
-      ) : (
-        <StFirstAddGuideKrTxt>
-          {
-            '목표를 이루기 위한 측정 가능한 이정표를 설정해볼거예요\n먼저, 목표를 달성하기 위해 어떤 성과들이 필요할까요?'
-          }
-        </StFirstAddGuideKrTxt>
-      )}
-
-      <StObjTitleBox>
-        <p>{objTitle}</p>
-      </StObjTitleBox>
-
-      <AddOkrCardWrapper>
-        {isActiveSecondKrCard ? renderSecondKrCards() : renderFirstKrCards()}
       </AddOkrCardWrapper>
     </section>
   );
 };
 
-export default AddGuideKr;
+export default AddGuideFirstKr;
 
 const AddGuideKrContainer = css`
   display: flex;
@@ -134,17 +88,6 @@ const StAddGuideKrTxt = styled.h1`
 
 const StFirstAddGuideKrTxt = styled(StAddGuideKrTxt)`
   margin: 1rem 0 0.6rem;
-`;
-
-const StSecondAddGuideKrTxt = styled(StAddGuideKrTxt)`
-  margin: 1rem 0 0.4rem;
-`;
-
-const StSubGuideTxt = styled.p`
-  margin-bottom: 1.6rem;
-  color: ${({ theme }) => theme.colors.sub_mint};
-
-  ${({ theme }) => theme.fonts.body_12_medium};
 `;
 
 const StObjTitleBox = styled.div`

--- a/src/AddOkr/components/stepLayout/AddGuideSecondKr.tsx
+++ b/src/AddOkr/components/stepLayout/AddGuideSecondKr.tsx
@@ -1,0 +1,81 @@
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+
+import { AddOkrCardWrapper, EmptyKeyResultCard } from '../../styles/KeyResultCardStyle';
+import { IAddKrFlowProps } from '../../types/KrInfoTypes';
+import GuideSecondKeyResultCard from '../addKr/GuideSecondKeyResultCard';
+
+const AddGuideSecondKr = ({ objInfo, clickedCard, krListInfo, setKrListInfo }: IAddKrFlowProps) => {
+  const { objTitle } = objInfo;
+  const secondKrList = [0, 1, 2];
+
+  return (
+    <section css={AddGuideKrContainer}>
+      <StSecondAddGuideKrTxt>
+        {'달에 탐사선을 쏘아올릴 마음으로, 목표를 측정할 수 있는 핵심 지표를 설정해주세요'}
+      </StSecondAddGuideKrTxt>
+      <StSubGuideTxt>
+        moonshot에서 설정되는 목표 값은 70%에 도달할 시 완료로 간주되어요
+      </StSubGuideTxt>
+
+      <StObjTitleBox>
+        <p>{objTitle}</p>
+      </StObjTitleBox>
+
+      <AddOkrCardWrapper>
+        {secondKrList.map((indexOfCard) => {
+          return clickedCard.includes(indexOfCard) ? (
+            <GuideSecondKeyResultCard
+              key={indexOfCard}
+              cardIdx={indexOfCard}
+              krListInfo={krListInfo}
+              setKrListInfo={setKrListInfo}
+            />
+          ) : (
+            <EmptyKeyResultCard key={indexOfCard} />
+          );
+        })}
+      </AddOkrCardWrapper>
+    </section>
+  );
+};
+
+export default AddGuideSecondKr;
+
+const AddGuideKrContainer = css`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+const StAddGuideKrTxt = styled.h1`
+  color: ${({ theme }) => theme.colors.gray_000};
+  text-align: center;
+  white-space: pre-line;
+
+  ${({ theme }) => theme.fonts.title_20_semibold};
+`;
+
+const StSecondAddGuideKrTxt = styled(StAddGuideKrTxt)`
+  margin: 1rem 0 0.4rem;
+`;
+
+const StSubGuideTxt = styled.p`
+  margin-bottom: 1.6rem;
+  color: ${({ theme }) => theme.colors.sub_mint};
+
+  ${({ theme }) => theme.fonts.body_12_medium};
+`;
+
+const StObjTitleBox = styled.div`
+  display: flex;
+  align-items: center;
+  width: fit-content;
+  height: 4.2rem;
+  padding: 0.7rem 0.5rem ${({ theme }) => theme.fonts.title_16_semibold};
+  margin-bottom: 3rem;
+  color: ${({ theme }) => theme.colors.main_purple};
+  border-bottom: 1px solid ${({ theme }) => theme.colors.main_purple};
+
+  ${({ theme }) => theme.fonts.title_16_semibold};
+`;

--- a/src/AddOkr/components/stepLayout/AddKr.tsx
+++ b/src/AddOkr/components/stepLayout/AddKr.tsx
@@ -17,6 +17,7 @@ const AddKr = ({
   setKrListInfo,
 }: IAddKrFlowProps) => {
   const { objTitle } = objInfo;
+
   const renderKrCards = () => {
     const plusCardLength = Array.from({ length: MAX_KR_LENGTH - 1 }, (_, i) => i + 1);
     return (
@@ -84,6 +85,7 @@ const StAddOkrTitle = styled.h1`
   color: ${({ theme }) => theme.colors.gray_000};
   ${({ theme }) => theme.fonts.title_20_semibold};
 
+  text-align: center;
   white-space: pre-line;
 `;
 

--- a/src/AddOkr/components/stepLayout/ObjContent.tsx
+++ b/src/AddOkr/components/stepLayout/ObjContent.tsx
@@ -3,9 +3,9 @@ import styled from '@emotion/styled';
 import { limitMaxLength } from '@utils/limitMaxLength';
 import { useState } from 'react';
 
+import { MAX_OBJ_CONTENT } from '../../constants/OKR_MAX_LENGTH';
 import { IAddObjFlowProps } from '../../types/ObjectInfoTypes';
 
-const MAX_OBJ_TEXTAREA_CNT = 100; //목표 다짐 제한 글자수
 // 기본 placeholder
 const OBJ_CONTENT_PLACEHOLDER =
   'ex) 앞으로 한 달간 다양한 마케팅을 통해 더 많은 고객을 유치하고 매출을 늘리고 싶기 때문이다.';
@@ -18,7 +18,7 @@ const ObjContent = ({ objInfo, setObjInfo }: IAddObjFlowProps) => {
   const handleContentTextarea = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     if (e.target.value === '') setCurrContentCnt(0);
 
-    const contentTextareaCnt = limitMaxLength(e, MAX_OBJ_TEXTAREA_CNT);
+    const contentTextareaCnt = limitMaxLength(e, MAX_OBJ_CONTENT);
 
     if (contentTextareaCnt) setCurrContentCnt(contentTextareaCnt);
     setObjInfo({ ...objInfo, objContent: e.target.value });
@@ -37,7 +37,7 @@ const ObjContent = ({ objInfo, setObjInfo }: IAddObjFlowProps) => {
           autoComplete="off"
         />
         <StContentTextAreaCntTxt>
-          {currContentCnt}/{MAX_OBJ_TEXTAREA_CNT}
+          {currContentCnt}/{MAX_OBJ_CONTENT}
         </StContentTextAreaCntTxt>
       </div>
     </section>

--- a/src/AddOkr/components/stepLayout/ObjPeriod.tsx
+++ b/src/AddOkr/components/stepLayout/ObjPeriod.tsx
@@ -15,6 +15,8 @@ interface IObjPeriodProps extends IAddObjFlowProps {
   setSelectedPeriod: React.Dispatch<React.SetStateAction<string>>;
 }
 
+const DEFAULT_SELECT_PERIOD = '1';
+
 const ObjPeriod = ({ objInfo, setObjInfo, selectedPeriod, setSelectedPeriod }: IObjPeriodProps) => {
   const { objStartAt, objExpireAt } = objInfo;
 
@@ -25,10 +27,14 @@ const ObjPeriod = ({ objInfo, setObjInfo, selectedPeriod, setSelectedPeriod }: I
   ]);
 
   const handleClickPeriodBtn = (e: React.MouseEvent<HTMLButtonElement>) => {
-    setSelectedPeriod(e.currentTarget.id);
+    let currPeriod = e.currentTarget.id;
+    setSelectedPeriod(currPeriod);
 
-    if (e.currentTarget.id === 'null') return;
-    const calcDate = addMonth(TODAY, Number(e.currentTarget.id));
+    // 날짜 선택 버튼 클릭시, 기본 값이 1개월이 되도록 설정
+    if (e.currentTarget.id === 'SELECT_PERIOD') currPeriod = DEFAULT_SELECT_PERIOD;
+
+    // expireDate 범위에 따라 추가 (stateDate은 오늘, 오늘 기준 + month)
+    const calcDate = addMonth(TODAY, Number(currPeriod));
     const dotParsedDate = returnParsedDate(calcDate, '. ');
     setObjInfo({
       ...objInfo,

--- a/src/AddOkr/components/stepLayout/ObjPeriod.tsx
+++ b/src/AddOkr/components/stepLayout/ObjPeriod.tsx
@@ -28,6 +28,10 @@ const ObjPeriod = ({ objInfo, setObjInfo, selectedPeriod, setSelectedPeriod }: I
 
   const handleClickPeriodBtn = (e: React.MouseEvent<HTMLButtonElement>) => {
     let currPeriod = e.currentTarget.id;
+
+    // SELECT_PERIOD 버튼 클릭 후 -> 날짜 선택 시 이벤트 전파 되는 것을 막고자 같은 버튼 id면 early return
+    if (selectedPeriod === currPeriod) return;
+
     setSelectedPeriod(currPeriod);
 
     // 날짜 선택 버튼 클릭시, 기본 값이 1개월이 되도록 설정
@@ -46,6 +50,7 @@ const ObjPeriod = ({ objInfo, setObjInfo, selectedPeriod, setSelectedPeriod }: I
     _values: [Dayjs | null, Dayjs | null] | null,
     formatString: [string, string],
   ) => {
+    event?.stopPropagation;
     if (formatString[0] && formatString[1]) {
       setPeriod(formatString);
       setObjInfo({ ...objInfo, objStartAt: formatString[0], objExpireAt: formatString[1] });

--- a/src/AddOkr/components/stepLayout/ObjTitleCateg.tsx
+++ b/src/AddOkr/components/stepLayout/ObjTitleCateg.tsx
@@ -5,14 +5,13 @@ import { useState } from 'react';
 
 import { GUIDE_OBJ_TITLE_PLACEHOLDER } from '../../constants/GUIDE_OBJ_TITLE_PLACEHOLDER';
 import { OBJ_CATEG_LIST } from '../../constants/OBJ_CATEG_LIST';
+import { MAX_OBJ_TITLE } from '../../constants/OKR_MAX_LENGTH';
 import { IAddObjFlowProps } from '../../types/ObjectInfoTypes';
 import ObjCategTag from '../objTitleCateg/ObjCategTag';
 
 interface IObjTitleCategProps extends IAddObjFlowProps {
   isGuide: boolean;
 }
-//object title input/textarea 최대 글자수
-const MAX_OBJ_INPUT_CNT = 30;
 
 // 가이드에 따라 설정하기 기본 placeholder
 const GUIDE_DEFAULT_PLACEHOLDER = '목표를 입력하세요';
@@ -38,7 +37,7 @@ const ObjTitleCateg = ({ isGuide, objInfo, setObjInfo }: IObjTitleCategProps) =>
   ) => {
     if (e.target.value === '') setCurrObjCount(0);
 
-    const objInputCnt = limitMaxLength(e, MAX_OBJ_INPUT_CNT);
+    const objInputCnt = limitMaxLength(e, MAX_OBJ_TITLE);
 
     if (objInputCnt) setCurrObjCount(objInputCnt);
     setObjInfo({ ...objInfo, objTitle: e.target.value });
@@ -98,7 +97,7 @@ const ObjTitleCateg = ({ isGuide, objInfo, setObjInfo }: IObjTitleCategProps) =>
             autoComplete="off"
           />
           <StObjTextAreaCntTxt>
-            {currObjCount}/{MAX_OBJ_INPUT_CNT}
+            {currObjCount}/{MAX_OBJ_TITLE}
           </StObjTextAreaCntTxt>
         </div>
       ) : (
@@ -112,7 +111,7 @@ const ObjTitleCateg = ({ isGuide, objInfo, setObjInfo }: IObjTitleCategProps) =>
             autoComplete="off"
           />
           <StObjInputCntTxt>
-            {currObjCount} / {MAX_OBJ_INPUT_CNT}
+            {currObjCount} / {MAX_OBJ_TITLE}
           </StObjInputCntTxt>
         </div>
       )}

--- a/src/AddOkr/components/stepLayout/SelectMethod.tsx
+++ b/src/AddOkr/components/stepLayout/SelectMethod.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 
-import { SELECT_METHOD_OPTIONS } from '../../constants/SELECT_METHOD_OPTIONS';
+import { SELECT_METHOD_OPTIONS } from '../../constants/ADD_OKR_METHOD_N_STEP';
 import SelectMethodBtn from '../selectMethod/SelectMethodBtn';
 
 interface ISelectMethodProps {

--- a/src/AddOkr/constants/ADD_OKR_METHOD_N_STEP.ts
+++ b/src/AddOkr/constants/ADD_OKR_METHOD_N_STEP.ts
@@ -1,3 +1,4 @@
+// ABOUT METHOD NAME
 export const SELECT_METHOD_OPTIONS = [
   {
     title: '가이드에 따라 설정하기',
@@ -10,3 +11,9 @@ export const SELECT_METHOD_OPTIONS = [
       'OKR 설정에 이미 익숙하거나,\n자신만의 방식으로 OKR을 설정하고 싶다면\n질문에 따라 자유롭게 목표와 성과 지표를 설정해 보세요\n\n\n(권장 소요시간 : 10분)',
   },
 ];
+
+export const IS_GUIDE = '가이드에 따라 설정하기';
+
+// ABOUT MAX STEP LENGTH
+export const MAX_BASIC_STEP = 5;
+export const MAX_GUIDE_STEP = 6;

--- a/src/AddOkr/constants/MAX_KR_LENGTH.ts
+++ b/src/AddOkr/constants/MAX_KR_LENGTH.ts
@@ -1,3 +1,0 @@
-export const MAX_KR_TITLE = 20;
-export const MAX_KR_TARGET = 6 + 1;
-export const MAX_KR_METRIC = 4;

--- a/src/AddOkr/constants/OBJ_PERIOD_LIST.ts
+++ b/src/AddOkr/constants/OBJ_PERIOD_LIST.ts
@@ -2,5 +2,5 @@ export const OBJ_PERIOD_LIST = [
   { length: '1', periodName: '1개월' },
   { length: '3', periodName: '3개월' },
   { length: '6', periodName: '6개월' },
-  { length: 'null', periodName: 'SELECT_PERIOD' },
+  { length: 'SELECT_PERIOD', periodName: 'SELECT_PERIOD' },
 ];

--- a/src/AddOkr/constants/OKR_MAX_LENGTH.ts
+++ b/src/AddOkr/constants/OKR_MAX_LENGTH.ts
@@ -1,0 +1,11 @@
+// OBJECTIVE
+export const MAX_OBJ_TITLE = 30; //object title input/textarea 최대 글자 수
+export const MAX_OBJ_CONTENT = 100; //목표 다짐 제한 글자 수
+
+// KEYRESULT
+export const MAX_KR_TITLE = 20; // key-result title 최대 글자 수
+export const MAX_KR_TARGET = 6 + 1; // key-result 수치값 최대 자리 수(범위) (6+쉼표 한자리)
+export const MAX_KR_METRIC = 4; // key-result 단위 값 최대 글자 수
+
+// TASK
+export const MAX_TASK_TITLE = 30; // task title 최대 글자수

--- a/src/AddOkr/index.tsx
+++ b/src/AddOkr/index.tsx
@@ -14,11 +14,8 @@ import ObjContent from './components/stepLayout/ObjContent';
 import ObjPeriod from './components/stepLayout/ObjPeriod';
 import ObjTitleCateg from './components/stepLayout/ObjTitleCateg';
 import { OBJ_START_AT } from './constants/ADD_OKR_DATES';
+import { IS_GUIDE, MAX_BASIC_STEP, MAX_GUIDE_STEP } from './constants/ADD_OKR_METHOD_N_STEP';
 import { IKrListInfoTypes } from './types/KrInfoTypes';
-
-const IS_GUIDE = '가이드에 따라 설정하기';
-const MAX_BASIC_STEP = 5;
-const MAX_GUIDE_STEP = 6;
 
 const AddOkr = () => {
   const location = useLocation();

--- a/src/AddOkr/index.tsx
+++ b/src/AddOkr/index.tsx
@@ -5,6 +5,7 @@ import styled from '@emotion/styled';
 import { useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 
+import PreviewOkr from '../PreviewOkr/PreviewOkr';
 import StepBtns from './components/commonUse/StepBtns';
 import AddGuideFirstKr from './components/stepLayout/AddGuideFirstKr';
 import AddGuideSecondKr from './components/stepLayout/AddGuideSecondKr';
@@ -107,18 +108,24 @@ const AddOkr = () => {
 
   const handleClickNextBtn = () => {
     // 가이드에 따라 설정하기 vs 직접 설정하기 구분 조건
-    if (
-      (step === 4 && selectedMethod !== IS_GUIDE) ||
-      (step === 5 && selectedMethod === IS_GUIDE)
-    ) {
-      navigate('/preview-okr', {
-        state: {
-          selectedMethod: selectedMethod,
-          step: step,
-          objInfo: objInfo,
-          krListInfo: krListInfo.filter((kr) => kr.title),
-        },
-      });
+    // if (
+    //   (step === 4 && selectedMethod !== IS_GUIDE) ||
+    //   (step === 5 && selectedMethod === IS_GUIDE)
+    // ) {
+    //   navigate('/preview-okr', {
+    //     state: {
+    //       selectedMethod: selectedMethod,
+    //       step: step,
+    //       objInfo: objInfo,
+    //       krListInfo: krListInfo.filter((kr) => kr.title),
+    //     },
+    //   });
+    // }
+
+    // 가이드에 따라 설정하기 vs 직접 설정하기 구분 조건 : 직접 설정하기일 때는 step 4 -> step 6로 preview okr로 이동
+    if (step === 4 && selectedMethod !== IS_GUIDE) {
+      setStep((prev) => prev + 2);
+      return;
     }
 
     // default function
@@ -188,6 +195,10 @@ const AddOkr = () => {
         }
         break;
       case 5:
+        if (selectedMethod !== IS_GUIDE) {
+          setStep((prev) => prev + 1);
+          return;
+        }
         //가이드에 따라 설정 - 두번째 kr 카드일 떄
         krListInfo.filter((kr) => {
           return clickedCard.includes(kr.idx);
@@ -270,6 +281,16 @@ const AddOkr = () => {
             handleClickCloseBtn={handleClickCloseBtn}
             krListInfo={krListInfo}
             setKrListInfo={setKrListInfo}
+          />
+        );
+      case 6:
+        //step 6 - preview Okr
+        return (
+          <PreviewOkr
+            selectedMethod={selectedMethod}
+            setStep={setStep}
+            objInfo={objInfo}
+            krListInfo={krListInfo.filter((kr) => kr.title)}
           />
         );
       default:

--- a/src/AddOkr/index.tsx
+++ b/src/AddOkr/index.tsx
@@ -114,6 +114,7 @@ const AddOkr = () => {
       navigate('/preview-okr', {
         state: {
           selectedMethod: selectedMethod,
+          step: step,
           objInfo: objInfo,
           krListInfo: krListInfo.filter((kr) => kr.title),
         },

--- a/src/AddOkr/index.tsx
+++ b/src/AddOkr/index.tsx
@@ -297,31 +297,36 @@ const AddOkr = () => {
   }, [step, objInfo, krListInfo, clickedCard]);
 
   return (
-    <section css={AddOkrContainer}>
-      {selectedMethod && <StSelectedMethodTxt>{selectedMethod}</StSelectedMethodTxt>}
-      {renderStepLayout()}
-      {selectedMethod && step <= 5 && (
-        <>
-          <StepBtns
-            isInit={step === 1}
-            isActiveNext={isActiveNext}
-            handleClickPrev={handleClickPrevBtn}
-            handleClickNext={handleClickNextBtn}
-          />
-          <StProgressBarBox $step={step} $selectedMethod={selectedMethod}>
-            <ProgressBar
-              currentProgress={step}
-              maximumProgress={selectedMethod === IS_GUIDE ? MAX_GUIDE_STEP : MAX_BASIC_STEP}
+    <>
+      {selectedMethod && step <= 5 ? (
+        <section css={AddOkrContainer}>
+          <StSelectedMethodTxt>{selectedMethod}</StSelectedMethodTxt>
+          {renderStepLayout()}
+          <>
+            <StepBtns
+              isInit={step === 1}
+              isActiveNext={isActiveNext}
+              handleClickPrev={handleClickPrevBtn}
+              handleClickNext={handleClickNextBtn}
             />
-            <div css={ProgressTxtBox}>
-              <StProgressTxt>{`${step}/${
-                selectedMethod === IS_GUIDE ? MAX_GUIDE_STEP : MAX_BASIC_STEP
-              }`}</StProgressTxt>
-            </div>
-          </StProgressBarBox>
-        </>
+            <StProgressBarBox $step={step} $selectedMethod={selectedMethod}>
+              <ProgressBar
+                currentProgress={step}
+                maximumProgress={selectedMethod === IS_GUIDE ? MAX_GUIDE_STEP : MAX_BASIC_STEP}
+              />
+              <div css={ProgressTxtBox}>
+                <StProgressTxt>{`${step}/${
+                  selectedMethod === IS_GUIDE ? MAX_GUIDE_STEP : MAX_BASIC_STEP
+                }`}</StProgressTxt>
+              </div>
+            </StProgressBarBox>
+          </>
+        </section>
+      ) : (
+        // step > 6, 즉 preview-okr에서는 페이지 정렬 다르게
+        renderStepLayout()
       )}
-    </section>
+    </>
   );
 };
 

--- a/src/AddOkr/index.tsx
+++ b/src/AddOkr/index.tsx
@@ -121,7 +121,7 @@ const AddOkr = () => {
 
     // 가이드에 따라 설정하기 vs 직접 설정하기 구분 조건 : 직접 설정하기일 때는 step 4 -> step 6로 preview okr로 이동
     if (step === 4 && selectedMethod !== IS_GUIDE) {
-      setStep((prev) => prev + 2);
+      isActiveNext && setStep((prev) => prev + 2);
       return;
     }
 
@@ -192,10 +192,6 @@ const AddOkr = () => {
         }
         break;
       case 5:
-        if (selectedMethod !== IS_GUIDE) {
-          setStep((prev) => prev + 1);
-          return;
-        }
         //가이드에 따라 설정 - 두번째 kr 카드일 떄
         krListInfo.filter((kr) => {
           return clickedCard.includes(kr.idx);

--- a/src/AddOkr/types/FinalKrListInfo.ts
+++ b/src/AddOkr/types/FinalKrListInfo.ts
@@ -5,6 +5,6 @@ export interface IFinalOkrListInfoTypes {
   objCategory: string;
   objContent: string;
   objStartAt: string;
-  objExpireAte: string;
+  objExpireAt: string;
   krList: IKrListInfoTypes[];
 }

--- a/src/AddOkr/types/KrInfoTypes.ts
+++ b/src/AddOkr/types/KrInfoTypes.ts
@@ -2,11 +2,12 @@ import { IObjInfoTypes } from './ObjectInfoTypes';
 import { ITaskInfoTypes } from './TaskInfoTypes';
 
 export interface IKrListInfoTypes {
-  title: string;
+  KeyResultTitle?: string;
+  title?: string;
   startAt: string;
   expireAt: string;
   idx: number;
-  target: string;
+  target: string | number;
   metric: string;
   taskList: ITaskInfoTypes[];
 }

--- a/src/MainDashBoard/components/mainDashBoardOkrTree/MainDashKrNodes.tsx
+++ b/src/MainDashBoard/components/mainDashBoardOkrTree/MainDashKrNodes.tsx
@@ -13,7 +13,7 @@ import { IcDrag } from '../../assets/icons';
 interface IMainDashKrNodesProps {
   krIdx: number;
   krList: IKeyResultTypes;
-  onShowSideSheet: (keyResultId: number) => void;
+  onShowSideSheet: (keyResultId: number | undefined) => void;
 }
 
 export const MainDashKrNodes = ({ krIdx, krList, onShowSideSheet }: IMainDashKrNodesProps) => {

--- a/src/MainDashBoard/components/mainDashBoardOkrTree/MainDashboardOKRTree.tsx
+++ b/src/MainDashBoard/components/mainDashBoardOkrTree/MainDashboardOKRTree.tsx
@@ -10,7 +10,7 @@ import { MainDashTaskNodes } from './MainDashTaskNodes';
 
 interface IMainDashboardOKRTreeProps {
   currentOkrData: IMainData;
-  onShowSideSheet: (keyResultId: number) => void;
+  onShowSideSheet: (keyResultId: number | undefined) => void;
 }
 
 const MainDashboardOKRTree = ({ onShowSideSheet, currentOkrData }: IMainDashboardOKRTreeProps) => {

--- a/src/MainDashBoard/index.tsx
+++ b/src/MainDashBoard/index.tsx
@@ -130,7 +130,8 @@ const MainDashBoard = () => {
   const okrTreeData = treeData?.data.tree;
   const goalListTreeData = treeData?.data.objList;
 
-  const handleShowSideSheet = (id: number) => {
+  const handleShowSideSheet = (id: number | undefined) => {
+    if (!id) return;
     setCurrentKrId(id);
     setShowSideSheet(true);
   };
@@ -139,7 +140,8 @@ const MainDashBoard = () => {
     setShowSideSheet(false);
   };
 
-  const handleCurrentGoalId = (id: number) => {
+  const handleCurrentGoalId = (id: number | number) => {
+    if (!id) return;
     setCurrentGoalId(id);
   };
 

--- a/src/PreviewOkr/PreviewOkr.tsx
+++ b/src/PreviewOkr/PreviewOkr.tsx
@@ -109,21 +109,21 @@ const PreviewOkr = ({ selectedMethod, setStep, objInfo, krListInfo }: IPreviewOk
       krList: [
         previewKrListInfo[0] && {
           ...previewKrListInfo[0],
-          target: Number(previewKrListInfo[0].target),
+          target: Number(previewKrListInfo[0].target.toString().split(',').join('')),
           startAt: previewKrListInfo[0].startAt.split('. ').join('-'),
           expireAt: previewKrListInfo[0].expireAt.split('. ').join('-'),
           taskList: previewTaskListInfo[0].taskList,
         },
         previewKrListInfo[1] && {
           ...previewKrListInfo[1],
-          target: Number(previewKrListInfo[1].target),
+          target: Number(previewKrListInfo[0].target.toString().split(',').join('')),
           startAt: previewKrListInfo[1].startAt.split('. ').join('-'),
           expireAt: previewKrListInfo[1].expireAt.split('. ').join('-'),
           taskList: previewTaskListInfo[1].taskList,
         },
         previewKrListInfo[2] && {
           ...previewKrListInfo[2],
-          target: Number(previewKrListInfo[2].target),
+          target: Number(previewKrListInfo[0].target.toString().split(',').join('')),
           startAt: previewKrListInfo[2].startAt.split('. ').join('-'),
           expireAt: previewKrListInfo[2].expireAt.split('. ').join('-'),
           taskList: previewTaskListInfo[2].taskList,
@@ -140,6 +140,7 @@ const PreviewOkr = ({ selectedMethod, setStep, objInfo, krListInfo }: IPreviewOk
     }
   };
 
+  // o, kr 값이 빈 값일 때 저장하기 비활성화를 위한 검증 함수
   const validEmptyValue = (e: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => {
     e.target.value === '' ? setIsActiveSave(false) : setIsActiveSave(true);
   };

--- a/src/PreviewOkr/PreviewOkr.tsx
+++ b/src/PreviewOkr/PreviewOkr.tsx
@@ -4,8 +4,9 @@ import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import useModal from '@hooks/useModal';
 import { Dispatch, SetStateAction, useEffect, useState } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 
+import { IS_GUIDE } from '../AddOkr/constants/ADD_OKR_METHOD_N_STEP';
 import { IFinalOkrListInfoTypes } from '../AddOkr/types/FinalKrListInfo';
 import { IKrListInfoTypes } from '../AddOkr/types/KrInfoTypes';
 import { IObjInfoTypes } from '../AddOkr/types/ObjectInfoTypes';
@@ -24,10 +25,8 @@ interface IPreviewOkrProps {
   krListInfo: IKrListInfoTypes[];
 }
 
-const IS_GUIDE = '가이드에 따라 설정하기';
-
 const PreviewOkr = ({ selectedMethod, setStep, objInfo, krListInfo }: IPreviewOkrProps) => {
-  const location = useLocation();
+  // const location = useLocation();
   const navigate = useNavigate();
 
   // const { step, selectedMethod, objInfo, krListInfo } = location.state;
@@ -157,7 +156,7 @@ const PreviewOkr = ({ selectedMethod, setStep, objInfo, krListInfo }: IPreviewOk
   };
 
   useEffect(() => {
-    location.state && handleShowModal();
+    handleShowModal();
   }, []);
 
   return (

--- a/src/PreviewOkr/PreviewOkr.tsx
+++ b/src/PreviewOkr/PreviewOkr.tsx
@@ -7,6 +7,7 @@ import { Dispatch, SetStateAction, useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { IS_GUIDE } from '../AddOkr/constants/ADD_OKR_METHOD_N_STEP';
+import { MAX_KR_TITLE, MAX_OBJ_TITLE } from '../AddOkr/constants/OKR_MAX_LENGTH';
 import { IFinalOkrListInfoTypes } from '../AddOkr/types/FinalKrListInfo';
 import { IKrListInfoTypes } from '../AddOkr/types/KrInfoTypes';
 import { IObjInfoTypes } from '../AddOkr/types/ObjectInfoTypes';
@@ -147,11 +148,18 @@ const PreviewOkr = ({ selectedMethod, setStep, objInfo, krListInfo }: IPreviewOk
 
   const handleChangeObjTextArea = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     validEmptyValue(e);
+
+    if (e.target.value.length > MAX_OBJ_TITLE)
+      e.target.value = e.target.value.slice(0, MAX_KR_TITLE);
     setPreviewObjValue(e.target.value);
   };
 
   const handleChangeKrTitleValue = (e: React.ChangeEvent<HTMLInputElement>, krIdx: number) => {
     validEmptyValue(e);
+
+    if (e.target.value.length > MAX_KR_TITLE)
+      e.target.value = e.target.value.slice(0, MAX_KR_TITLE);
+
     previewKrListInfo[krIdx].title = e.target.value;
     setPreviewKrListInfo([...previewKrListInfo]);
   };

--- a/src/PreviewOkr/PreviewOkr.tsx
+++ b/src/PreviewOkr/PreviewOkr.tsx
@@ -3,11 +3,12 @@ import OkrTreeTemplate from '@components/okrTree/template/OkrTreeTemplate';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import useModal from '@hooks/useModal';
-import { useEffect, useState } from 'react';
+import { Dispatch, SetStateAction, useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 
 import { IFinalOkrListInfoTypes } from '../AddOkr/types/FinalKrListInfo';
 import { IKrListInfoTypes } from '../AddOkr/types/KrInfoTypes';
+import { IObjInfoTypes } from '../AddOkr/types/ObjectInfoTypes';
 import { IPreviewTaskInfoTypes } from '../AddOkr/types/TaskInfoTypes';
 import { postOkrInfo } from './apis/postOkrFetcher';
 import PreviewModal from './components/PreviewModal';
@@ -16,13 +17,20 @@ import { PreviewKrNodes } from './components/PreviewOkrTreeNodes/PreviewKrNodes'
 import PreviewObjNode from './components/PreviewOkrTreeNodes/PreviewObjNode';
 import { PreviewTaskNodes } from './components/PreviewOkrTreeNodes/PreviewTaskNodes';
 
-const PreviewOkr = () => {
+interface IPreviewOkrProps {
+  selectedMethod: string;
+  setStep: Dispatch<SetStateAction<number>>;
+  objInfo: IObjInfoTypes;
+  krListInfo: IKrListInfoTypes[];
+}
+
+const IS_GUIDE = '가이드에 따라 설정하기';
+
+const PreviewOkr = ({ selectedMethod, setStep, objInfo, krListInfo }: IPreviewOkrProps) => {
   const location = useLocation();
   const navigate = useNavigate();
 
-  const { step, selectedMethod, objInfo, krListInfo } = location.state;
-
-  console.log(step);
+  // const { step, selectedMethod, objInfo, krListInfo } = location.state;
 
   const { modalRef, handleShowModal } = useModal();
 
@@ -85,6 +93,10 @@ const PreviewOkr = () => {
     },
   ]);
 
+  const handleClickPrevBtn = () => {
+    setStep((prev) => prev - (selectedMethod === IS_GUIDE ? 1 : 2));
+  };
+
   const handleClickSaveOkrBtn = async () => {
     if (!isActiveSave) return;
 
@@ -98,21 +110,21 @@ const PreviewOkr = () => {
       krList: [
         previewKrListInfo[0] && {
           ...previewKrListInfo[0],
-          target: Number(previewKrListInfo[0].target.split(',').join('')),
+          target: Number(previewKrListInfo[0].target),
           startAt: previewKrListInfo[0].startAt.split('. ').join('-'),
           expireAt: previewKrListInfo[0].expireAt.split('. ').join('-'),
           taskList: previewTaskListInfo[0].taskList,
         },
         previewKrListInfo[1] && {
           ...previewKrListInfo[1],
-          target: Number(previewKrListInfo[1].target.split(',').join('')),
+          target: Number(previewKrListInfo[1].target),
           startAt: previewKrListInfo[1].startAt.split('. ').join('-'),
           expireAt: previewKrListInfo[1].expireAt.split('. ').join('-'),
           taskList: previewTaskListInfo[1].taskList,
         },
         previewKrListInfo[2] && {
           ...previewKrListInfo[2],
-          target: Number(previewKrListInfo[2].target.split(',').join('')),
+          target: Number(previewKrListInfo[2].target),
           startAt: previewKrListInfo[2].startAt.split('. ').join('-'),
           expireAt: previewKrListInfo[2].expireAt.split('. ').join('-'),
           taskList: previewTaskListInfo[2].taskList,
@@ -186,7 +198,9 @@ const PreviewOkr = () => {
         </div>
 
         <StBtnWrapper>
-          <StPrevBtn type="button">이전으로</StPrevBtn>
+          <StPrevBtn type="button" onClick={handleClickPrevBtn}>
+            이전으로
+          </StPrevBtn>
           <StSaveBtn type="button" onClick={handleClickSaveOkrBtn} $isActiveSave={isActiveSave}>
             저장하기
           </StSaveBtn>

--- a/src/PreviewOkr/components/PreviewModal.tsx
+++ b/src/PreviewOkr/components/PreviewModal.tsx
@@ -1,10 +1,17 @@
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 
-const IS_GUIDE = '가이드에 따라 설정하기';
+import {
+  IS_GUIDE,
+  MAX_BASIC_STEP,
+  MAX_GUIDE_STEP,
+} from '../../AddOkr/constants/ADD_OKR_METHOD_N_STEP';
 
 const PreviewModal = ({ selectedMethod }: { selectedMethod: string }) => {
-  const progressStep = selectedMethod === IS_GUIDE ? '6/6' : '5/5';
+  const progressStep =
+    selectedMethod === IS_GUIDE
+      ? `${MAX_GUIDE_STEP}/${MAX_GUIDE_STEP}`
+      : `${MAX_BASIC_STEP}/${MAX_BASIC_STEP}`;
 
   return (
     <>

--- a/src/PreviewOkr/components/PreviewOkrTreeNodes/PreviewKrNodes.tsx
+++ b/src/PreviewOkr/components/PreviewOkrTreeNodes/PreviewKrNodes.tsx
@@ -9,7 +9,7 @@ import {
 } from '@styles/okrTree/CommonNodeStyle';
 import React from 'react';
 
-import { MAX_KR_TITLE } from '../../../AddOkr/constants/MAX_KR_LENGTH';
+import { MAX_KR_TITLE } from '../../../AddOkr/constants/OKR_MAX_LENGTH';
 import { IKrListInfoTypes } from '../../../AddOkr/types/KrInfoTypes';
 
 interface IPreviewKrNodesProps {

--- a/src/PreviewOkr/components/PreviewOkrTreeNodes/PreviewKrNodes.tsx
+++ b/src/PreviewOkr/components/PreviewOkrTreeNodes/PreviewKrNodes.tsx
@@ -14,23 +14,18 @@ import { IKrListInfoTypes } from '../../../AddOkr/types/KrInfoTypes';
 
 interface IPreviewKrNodesProps {
   krIdx: number;
+  handleChangeKrTitleValue: (e: React.ChangeEvent<HTMLInputElement>, krIdx: number) => void;
   previewKrListInfo: IKrListInfoTypes[];
-  setPreviewKrListInfo: React.Dispatch<React.SetStateAction<IKrListInfoTypes[]>>;
 }
 
 export const PreviewKrNodes = ({
   krIdx,
   previewKrListInfo,
-  setPreviewKrListInfo,
+  handleChangeKrTitleValue,
 }: IPreviewKrNodesProps) => {
   const title = previewKrListInfo[krIdx].title;
   const target = previewKrListInfo[krIdx].target;
   const metric = previewKrListInfo[krIdx].metric;
-
-  const handleChangeTitleValue = (e: React.ChangeEvent<HTMLInputElement>) => {
-    previewKrListInfo[krIdx].title = e.target.value;
-    setPreviewKrListInfo([...previewKrListInfo]);
-  };
 
   return (
     <StNodesContainer>
@@ -40,7 +35,7 @@ export const PreviewKrNodes = ({
         <StPreviewKrBox>
           <DynamicInput
             value={title}
-            handleChangeValue={handleChangeTitleValue}
+            handleChangeValue={(e) => handleChangeKrTitleValue(e, krIdx)}
             maxLength={MAX_KR_TITLE}
           />
 

--- a/src/PreviewOkr/components/PreviewOkrTreeNodes/PreviewTaskNodes.tsx
+++ b/src/PreviewOkr/components/PreviewOkrTreeNodes/PreviewTaskNodes.tsx
@@ -12,6 +12,7 @@ import {
 import { ITaskNodesTypes } from '@type/okrTree/TasksTypes';
 import { useState } from 'react';
 
+import { MAX_TASK_TITLE } from '../../../AddOkr/constants/OKR_MAX_LENGTH';
 import { IPreviewTaskInfoTypes } from '../../../AddOkr/types/TaskInfoTypes';
 import { IcPlusSmall } from '../../assets/icons';
 
@@ -19,8 +20,6 @@ interface IPreviewTaskNodesProps extends ITaskNodesTypes {
   previewTaskListInfo: IPreviewTaskInfoTypes[];
   setPreviewTaskListInfo: React.Dispatch<React.SetStateAction<IPreviewTaskInfoTypes[]>>;
 }
-
-const MAX_TASK_LENGTH = 30;
 
 export const PreviewTaskNodes = ({
   isFirstChild,
@@ -34,6 +33,9 @@ export const PreviewTaskNodes = ({
   const title = previewTaskListInfo[krIdx].taskList[taskIdx].title;
 
   const handleChangeTaskValue = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.value.length > MAX_TASK_TITLE)
+      e.target.value = e.target.value.slice(0, MAX_TASK_TITLE);
+
     previewTaskListInfo[krIdx].taskList[taskIdx].title = e.target.value;
     setPreviewTaskListInfo([...previewTaskListInfo]);
   };
@@ -56,7 +58,7 @@ export const PreviewTaskNodes = ({
                 value={title}
                 handleChangeValue={handleChangeTaskValue}
                 isAutoFocus={true}
-                maxLength={MAX_TASK_LENGTH}
+                maxLength={MAX_TASK_TITLE}
               />
             </StPreviewTaskBox>
           ) : (

--- a/src/PreviewOkr/index.tsx
+++ b/src/PreviewOkr/index.tsx
@@ -20,11 +20,16 @@ const PreviewOkr = () => {
   const location = useLocation();
   const navigate = useNavigate();
 
+  const { step, selectedMethod, objInfo, krListInfo } = location.state;
+
+  console.log(step);
+
   const { modalRef, handleShowModal } = useModal();
 
-  const { selectedMethod, objInfo, krListInfo } = location.state;
+  // '저장하기' 버튼 활성화 비활성화 관리
+  const [isActiveSave, setIsActiveSave] = useState(true);
+  // o, kr, task 값 입력 관리
   const [previewObjValue, setPreviewObjValue] = useState(objInfo.objTitle);
-
   const [previewKrListInfo, setPreviewKrListInfo] = useState<IKrListInfoTypes[]>(krListInfo);
   const [previewTaskListInfo, setPreviewTaskListInfo] = useState<IPreviewTaskInfoTypes[]>([
     {
@@ -81,6 +86,8 @@ const PreviewOkr = () => {
   ]);
 
   const handleClickSaveOkrBtn = async () => {
+    if (!isActiveSave) return;
+
     const { objStartAt, objExpireAt } = objInfo;
 
     const finalOkrInfo: IFinalOkrListInfoTypes = {
@@ -122,8 +129,19 @@ const PreviewOkr = () => {
     }
   };
 
+  const validEmptyValue = (e: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => {
+    e.target.value === '' ? setIsActiveSave(false) : setIsActiveSave(true);
+  };
+
   const handleChangeObjTextArea = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    validEmptyValue(e);
     setPreviewObjValue(e.target.value);
+  };
+
+  const handleChangeKrTitleValue = (e: React.ChangeEvent<HTMLInputElement>, krIdx: number) => {
+    validEmptyValue(e);
+    previewKrListInfo[krIdx].title = e.target.value;
+    setPreviewKrListInfo([...previewKrListInfo]);
   };
 
   useEffect(() => {
@@ -151,8 +169,8 @@ const PreviewOkr = () => {
             KrNodes={(krIdx) => (
               <PreviewKrNodes
                 krIdx={krIdx}
+                handleChangeKrTitleValue={handleChangeKrTitleValue}
                 previewKrListInfo={previewKrListInfo}
-                setPreviewKrListInfo={setPreviewKrListInfo}
               />
             )}
             TaskNodes={(isFirstChild, krIdx, taskIdx) => (
@@ -167,9 +185,12 @@ const PreviewOkr = () => {
           />
         </div>
 
-        <StSaveOkrBtn type="button" onClick={handleClickSaveOkrBtn}>
-          저장하기
-        </StSaveOkrBtn>
+        <StBtnWrapper>
+          <StPrevBtn type="button">이전으로</StPrevBtn>
+          <StSaveBtn type="button" onClick={handleClickSaveOkrBtn} $isActiveSave={isActiveSave}>
+            저장하기
+          </StSaveBtn>
+        </StBtnWrapper>
       </section>
     </>
   );
@@ -196,18 +217,31 @@ const okrTreeDiv = css`
   margin-bottom: 8rem;
 `;
 
-const StSaveOkrBtn = styled.button`
-  position: absolute;
+const StBtnWrapper = styled.div`
+  position: fixed;
   bottom: 0;
+  display: flex;
+  gap: 1.2rem;
+  width: fit-content;
+  margin-bottom: 4.6rem;
+`;
+
+const StPrevBtn = styled.button`
   display: flex;
   align-items: center;
   justify-content: center;
   width: 17.8rem;
   height: 3.4rem;
-  margin-bottom: 4.6rem;
-  color: ${({ theme }) => theme.colors.gray_650};
-  background: ${({ theme }) => theme.colors.gray_100};
+  color: ${({ theme }) => theme.colors.gray_000};
+  background: ${({ theme }) => theme.colors.gray_550};
   border-radius: 6px;
+
+  ${({ theme }) => theme.fonts.btn_14_semibold};
+`;
+
+const StSaveBtn = styled(StPrevBtn)<{ $isActiveSave: boolean }>`
+  color: ${({ theme, $isActiveSave }) => $isActiveSave && theme.colors.gray_650};
+  background-color: ${({ theme, $isActiveSave }) => $isActiveSave && theme.colors.gray_100};
 
   ${({ theme }) => theme.fonts.btn_14_semibold};
 `;

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -16,7 +16,7 @@ const MainLayout = lazy(() => import('@components/Layout/MainLayout'));
 const My = lazy(() => import('./My'));
 const Nickname = lazy(() => import('./Nickname'));
 const TeamMoonshot = lazy(() => import('./Onboarding/components/teamMoonshot/TeamMoonshot'));
-const PreviewOkr = lazy(() => import('./PreviewOkr'));
+// const PreviewOkr = lazy(() => import('./PreviewOkr'));
 const SignIn = lazy(() => import('./SignIn'));
 const Social = lazy(() => import('./Social'));
 
@@ -60,10 +60,10 @@ const router = createBrowserRouter([
         path: 'social',
         element: <Social />,
       },
-      {
-        path: 'preview-okr',
-        element: <PreviewOkr />,
-      },
+      // {
+      //   path: 'preview-okr',
+      //   element: <PreviewOkr />,
+      // },
       {
         path: 'dashboard',
         element: <MainDashBoard />,

--- a/src/common/components/input/DynamicInput.tsx
+++ b/src/common/components/input/DynamicInput.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 import React, { useEffect, useRef, useState } from 'react';
 
 interface IDynamicInputProps {
-  value: string;
+  value?: string;
   handleChangeValue: (e: React.ChangeEvent<HTMLInputElement>) => void;
   minWidth?: number;
   maxLength?: number;

--- a/src/common/type/okrTree/KeyResultTypes.ts
+++ b/src/common/type/okrTree/KeyResultTypes.ts
@@ -1,14 +1,14 @@
 import { ITaskTypes } from './TasksTypes';
 
 export interface IKeyResultTypes {
-  keyResultTitle: string;
-  keyResultId: number;
+  keyResultId?: number;
+  // FIXME: 보낼 땐 title, 받을 땐 KeyResultTitle이라고 와 type 에러 발생 해 이를 방지하고자 둘 다 추가 추후 수정 예정
+  keyResultTitle?: string;
+  title?: string;
   startAt?: string;
   expireAt?: string;
   idx: number;
-  target?: number;
+  target?: number | string;
   metric?: string;
-  descriptionBefore?: string;
-  descriptionAfter?: string;
   taskList?: ITaskTypes[];
 }


### PR DESCRIPTION
## 🔥 Related Issues

- close #215

## 💜 작업 내용
### 1. add-okr 플로우
- [x] add-okr 날짜 필드 기본 값일 때도 활성화 / 앞에 설정한 objective 기본 값이 kr 기본 값에 반영되도록 (자동 입력에 대한 수정 사항 반영)
- [x] datepicker 숫자/아이콘 겹치는 이슈
- [x] 핵심 지표 설명 질문 중앙 정렬
- [x] guide 플로우, 두번째 kr 카드 단계에서 텍스트 입력 전에도 다음 버튼 활성화 됨: guide 플로우에서 kr 카드 단계 분할

### 2. preview-okr 플로우
- [x] 최대 범위 입력시 부자연스러운 수정 : 한글 byte에 따른 오류
- [x] objective, key result 값 없을 때의 예외처리 (저장하기 버튼 비활성화)
- [x] preview-okr 이전 버튼 추가 (add-okr 로직에 step 6으로합병)
- [ ] task 입력 시 텍스트 깜빡임

## ✅ PR Point
📌 previewOkr을 addOkr 플로우에 병합시키고, 눈에 거슬리는 부분 파일 분리 하다 보니 변동 사항이 좀 많이 뜨네요,, 대형 수정 사항 위주로 pr point 작성했으니 pr point 위주로 확인 해주세요!
📌 플로우 수정한 부분이 많아 코드 보다 커밋 링크 보는게 편리할것 같아 관련 링크 달아 두겠습니다!

### 1. ➕ add-okr 플로우
1️⃣ **add-okr 날짜 필드 기본 값일 때도 활성화 / 앞에 설정한 objective 기본 값이 kr 기본 값에 반영되도록 (자동 입력에 대한 수정 사항 반영)**
* `AS-IS (수정 전)` : 
(1) add-okr에서 objective period, kr period 등 datepicker를 사용하는 선택지와 input에서 한번 클릭시 기본 범위(한 달)의 기간이 나오지만, '다음' 버튼(isActiveNext)이 활성화 되지 않았음. 따라서 사용자의 action이 datepicker 클릭 -> 기본 범위 기간 보여짐 -> (어? 왜 안넘어가나요 웅성웅성 혼란 발생 => 아 그거 날짜 클릭 해야 돼!) -> 원하는 범위의 날짜 선택으로 이루어져야 다음 버튼이 활성화 되었습니다. 
(2) objective period의 기간 내에 kr period가 설정되어야 했지만, 의존 관계 없이 objecive period, kr period 둘 다 기본 범위가 '한 달'로 고정 되어 있었습니다.

* `TO-BE (수정 후)` :
(1) 사용자가 겪을 혼란을 줄이기 위해 기본 범위의 기간이 보여질 때도, 해당 period 값을 기본 범위 기간으로 저장 후 '다음' 버튼을 활성화 해 다음 step으로 이동 가능하도록 수정하였습니다.
(* 관련 커밋 링크 : [링크1](https://github.com/MOONSHOT-Team/MOONSHOT-CLIENT/pull/224/commits/0b49d23934311a7d3d9ff3ddb923e00f73cd3dbb), [링크2](https://github.com/MOONSHOT-Team/MOONSHOT-CLIENT/pull/224/commits/382f40b9beb91dc65e9ba21d775024c689559ec9))
(2) objective period 기간에 따라 kr period의 기본 범위 기간이 유동적으로 변화하도록 의존 관계를 추가했습니다.
(* 관련 커밋 링크:  [링크1](https://github.com/MOONSHOT-Team/MOONSHOT-CLIENT/pull/224/commits/f49f1e349b9b81df75d9c3f200aac40355b1f44a), [링크2](https://github.com/MOONSHOT-Team/MOONSHOT-CLIENT/pull/224/commits/d4a52179f06f244959d5da6b7cbd63fe8ecfd89c))

2️⃣ **guide 플로우, 두번째 kr 카드 단계에서 텍스트 입력 전에도 다음 버튼 활성화 됨: guide 플로우에서 kr 카드 단계 분할**
*  `AS-IS (수정 전)`
(1) IS GUIDE 플로우(가이드에 따라 설정하기)와, 직접 설정하기의 step을 맞춰주기 위해 step 4에서 guide 플로우의 kr 카드 입력 단계(1: 첫번째 kr 카드(title: 성과 & period: 달성 기간 입력), 2: 두번째 kr 카드(target: 수치 값, metric: 단위 값 입력))를  한 step에서, 조건부로 나누어 관리 했습니다. 그러자 validation하는 함수에서 로직이 꼬여 필수 값이 모두 입력 되지 않았음에도 '다음' 버튼이 활성화 되는 오류가 발생했습니다.

* `TO-BE (수정 후)` :
(1) step은 setStep 함수에서 맞춰주면 되고, 후반부 step이기 때문에 가이드 플로우, 직접 설정하기 플로우에서 꼭 같아야 할 필요성이 없다고 느껴 두번째 kr 카드 레이아웃을 `step 5`, 즉 새로운 step으로 분할하여 로직을 확실히 구분했습니다.
(2) step layout 로직이 분리되어 validation 함수의 로직도 분리시킬수 있었고, 필수 값이 모두 입력 되어야 '다음' 버튼이 활성화 될 수 있도록 수정 완료 했습니다.
( * [관련 커밋 링크](https://github.com/MOONSHOT-Team/MOONSHOT-CLIENT/pull/224/commits/cc6a05ff2032cf0e9544f145716cf8665b85c35c))

<hr/>
<br/>

### 2. 🔮 preview-okr 플로우
1️⃣ **preview-okr 이전 버튼 추가 (add-okr 로직에 step 6으로합병)**
* `AS-IS (수정 전)` :
(1) preview-okr에도 이전 step으로 돌아갈수 있는 '이전으로' 버튼이 추가 되었습니니다. 이에 따라 이전으로 버튼 클릭 시 이전 add-okr에서 작성했던 정보들이 남아 있어야 하는 기능이 추가 되어야 합니다.

* `TO-BE (수정 후)`: 
(1) preview-okr의 '저장하기' 버튼 옆에 이전으로 버튼 디자인을 추가했습니다.
(2) preview-okr에서 '이전으로' 버튼을 눌러 이전 add-okr에서 작성한 정보를 다시 보여주기 위해, 크게 두가지 방안을 생각했습니다.

_❶ naviagte state 사용 (`/add-okr`, `/preview-okr` 페이지 분리)_ : navigate state로 정보들을 쏴줘서 가지고 있다가, 이전으로 버튼을 눌러 다시 /add-okr 페이지로 넘어갔을 때, navigate state에 있는 값을 기본 값으로 가져오기
_❷ add-okr의 마지막 step(step6)으로 preview-okr 추가_ : /preview-okr 없이 /add-okr 페이지 내에서 preview okr 플로우까지 step에 따른 레이아웃 렌더링으로 관리하기

❶의 장점은 preview-okr 페이지가 분리되어서, preview-okr 화면에서 새로고침 해도 add-okr의 처음 step으로 돌아가지 않고 preview-okr 화면이 남아 있을수 있다는 점이며 / 단점은 navigate시에 들고 다녀야 할 state 값이 많고, 케이스가 다양해져 기본 값을 관리하기 복잡해진다는 점이라 생각했습니다.
❷의 장점은 url이 하나로 합쳐져 유저가 주소창으로 접속(add-okr 플로우는 대시보드에서 연결되는 플로우이기 때문에 직접 접속 불가능)하는 엣지 케이스가 줄어 관리가 용이하며 필요한 state들이 한 페이지 내에 관리하여 가독성이 좋고 값을 관리하기 편하다는 점이며 / 단점은 previewOkr도 한 페이지에서 관리하기 때문에 새로고침시 add-okr의 첫번째 step으로 돌아간다는 점이라 생각했습니다.

고민하다가, add-okr에서 관리해야 할 state들이 꽤 많으며 이를 navigate에서 모두 들고 있기에 비효율적이라 생각했으며, 새로 고침시 유지(임시저장st)는 추후 localstorage로 관리하는게 맞다는 생각이 들었고, preview-okr 역시 유저 입장에서는 add-okr(okr 추가) 플로우의 한 부분이라 느껴질것이라 생각해 `❷add-okr의 마지막 step(step6)으로 preview-okr 추가`로 구현했습니다!

step 6으로 추가했고,
preview-okr은 add-okr과 레이아웃이 달라 return 문에서 조건을 걸어줬습니다.
바꾸는 과정에서 변동된 파일이 많아 자세한 변동사항은 아래 커밋 링크를 가볍게 보시면 좋을것 같습니다.
( * [커밋 링크]https://github.com/MOONSHOT-Team/MOONSHOT-CLIENT/pull/224/commits/1c1e159fc2557800cc8410da479416b768eed0a6))

### ‼️ (TO 수연 @SooY2 : preview-okr 합치면서 okr 트리에서 타입 에러가 많이 발생 해 type 정의를 바꾼게 몇개 있는데, mainDashboard와 social 트리에서 문제 없는지 확인 부탁해요! 일단 build 에러 해결하면서 에러 나는 부분 수정하긴 했습니당-! / 또, api 명세서를 보니까 okr을 생성하며 서버에 요청 보낼 때는 keyresult의 title의 필드 명이 `title`로 되어 있는데, 서버에서 받아 와서 사용할 때는 `keyResultTitle`로 되어 있어 맞추기가 곤란해.. 일단 두 개 다 타입에 nullable로 정의해 해결하긴 했는데 이 부분 통일시킬수 있는지 의논 해보는게 좋을것 같아요! FIXME로 메모 남겨 놓았습니다)


## 😡 Trouble Shooting

- preview-okr에서 dynamic input(input 입력 값에 따라 유동적으로 넓이 변하는 input) 입력 시  깜빡이는 현상이 있어 이를 수정하고 싶은데, 아예 구조를 바꿔야 할것 같아 고민 중에 있습니다.. 우선 다른거 먼저 머지 하고 더 고민해보고 구현 할 예정입니다!

## ☀️ 스크린샷 / GIF / 화면 녹화

