### PR TITLE
[SP1/feat] KR 추가 삭제, Task 추가 삭제 관련 API 수정 사항 반영, 데이터 캐싱 반영(mutate)

### DIFF
--- a/src/MainDashBoard/components/editModeModal/AddKrModal.tsx
+++ b/src/MainDashBoard/components/editModeModal/AddKrModal.tsx
@@ -12,6 +12,7 @@ interface IAddKrModalProps {
   modalRef: React.MutableRefObject<HTMLDialogElement | null>;
   objInfo: { objId: number; objStartAt: string; objExpireAt: string; objTitle: string };
   krIdx: number;
+  mutateFcn: () => void;
 }
 const KrModalFormStyle = {
   gap: '3.2rem',
@@ -25,7 +26,7 @@ const KrModalFormStyle = {
 };
 
 //TODO: 공통 컴포넌트 사용으로, 핸들러 완성 후 뷰 다시 확인하기
-const AddKrModal = ({ modalRef, objInfo, krIdx }: IAddKrModalProps) => {
+const AddKrModal = ({ modalRef, objInfo, krIdx, mutateFcn }: IAddKrModalProps) => {
   const navigate = useNavigate();
   const { objStartAt, objExpireAt, objId } = objInfo;
 
@@ -112,6 +113,7 @@ const AddKrModal = ({ modalRef, objInfo, krIdx }: IAddKrModalProps) => {
 
     try {
       await postAddKr('/v1/key-result', reqData);
+      mutateFcn();
     } catch {
       navigate('/error');
     }

--- a/src/MainDashBoard/components/editModeModal/AddKrModal.tsx
+++ b/src/MainDashBoard/components/editModeModal/AddKrModal.tsx
@@ -102,12 +102,12 @@ const AddKrModal = ({ modalRef, objInfo, krIdx }: IAddKrModalProps) => {
   const handleClickConfirmAddBtn = async () => {
     const reqData = {
       objectiveId: objId,
-      title: newKrInfo.krTitle,
-      startAt: newKrInfo.krStartAt.split('. ').join('-'),
-      expireAt: newKrInfo.krExpireAt.split('. ').join('-'),
-      idx: krIdx,
-      target: Number(newKrInfo.krTarget.toString().split(',').join('')),
-      metric: newKrInfo.krMetric,
+      krTitle: newKrInfo.krTitle,
+      krStartAt: newKrInfo.krStartAt.split('. ').join('-'),
+      krExpireAt: newKrInfo.krExpireAt.split('. ').join('-'),
+      krIdx: krIdx,
+      krTarget: Number(newKrInfo.krTarget.toString().split(',').join('')),
+      krMetric: newKrInfo.krMetric,
     };
 
     try {

--- a/src/MainDashBoard/components/editOkrTree/EditKrNodes.tsx
+++ b/src/MainDashBoard/components/editOkrTree/EditKrNodes.tsx
@@ -8,10 +8,11 @@ import {
   StNodesContainer,
 } from '@styles/okrTree/CommonNodeStyle';
 import { IKeyResultTypes } from '@type/okrTree/KeyResultTypes';
-import { useEffect, useState } from 'react';
+import { Dispatch, SetStateAction, useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import useSWR from 'swr';
 
-import { deletOkrInstance } from '../../apis/fetcher';
+import { deletOkrInstance, getDashBoardData } from '../../apis/fetcher';
 import { IcAdd, IcDrag, IcTrashPurple } from '../../assets/icons';
 import DeleteKrModal from '../editModeModal/DeleteKrModal';
 
@@ -20,10 +21,25 @@ interface IMainEditKrNodesProps {
   krList: IKeyResultTypes;
   krId: number | undefined;
   handleAddTask: (krId: number | undefined) => void;
+  objId: number;
+  state: string;
+  setState: Dispatch<SetStateAction<string>>;
 }
 
-export const EditKrNodes = ({ krIdx, krList, krId, handleAddTask }: IMainEditKrNodesProps) => {
+export const EditKrNodes = ({
+  krIdx,
+  krList,
+  krId,
+  handleAddTask,
+  objId,
+  state,
+  setState,
+}: IMainEditKrNodesProps) => {
   const navigate = useNavigate();
+
+  const url = objId ? `/v1/objective?objectiveId=${objId}` : '/v1/objective';
+  const { mutate } = useSWR(url, getDashBoardData);
+
   const { modalRef, handleShowModal } = useModal();
 
   const [isntFull, setIsntFull] = useState(false);
@@ -31,8 +47,9 @@ export const EditKrNodes = ({ krIdx, krList, krId, handleAddTask }: IMainEditKrN
   //kr 삭제하는 handler (kr 삭제 확인 모달의 삭제 버튼 클릭시 동작)
   const handleConfirmDelKr = async () => {
     try {
-      const res = await deletOkrInstance(`/v1/key-result/${krId}`);
-      if (!res) return;
+      await deletOkrInstance(`/v1/key-result/${krId}`);
+      mutate();
+      setState(state);
     } catch {
       navigate('/error');
     }

--- a/src/MainDashBoard/components/editOkrTree/EditObjectNode.tsx
+++ b/src/MainDashBoard/components/editOkrTree/EditObjectNode.tsx
@@ -7,8 +7,10 @@ import {
 import styled from '@emotion/styled';
 import useModal from '@hooks/useModal';
 import { StNodesContainer } from '@styles/okrTree/CommonNodeStyle';
-import { useEffect, useState } from 'react';
+import { Dispatch, SetStateAction, useEffect, useState } from 'react';
+import useSWR from 'swr';
 
+import { getDashBoardData } from '../../apis/fetcher';
 import { IcAdd } from '../../assets/icons';
 import AddKrModal from '../editModeModal/AddKrModal';
 import { IMainBoardObjNodeProps, StMainDashObjP } from '../mainDashBoardOkrTree/MainDashObjectNode';
@@ -16,15 +18,24 @@ import { IMainBoardObjNodeProps, StMainDashObjP } from '../mainDashBoardOkrTree/
 interface IEditObjectNode extends IMainBoardObjNodeProps {
   objInfo: { objId: number; objStartAt: string; objExpireAt: string; objTitle: string };
   krListLen: number;
+  state: string;
+  setState: Dispatch<SetStateAction<string>>;
 }
 
-const EditObjectNode = ({ objStroke, objInfo, krListLen }: IEditObjectNode) => {
-  const { objTitle } = objInfo;
-  // const navigate = useNavigate();
+const EditObjectNode = ({ objStroke, objInfo, krListLen, state, setState }: IEditObjectNode) => {
+  const { objTitle, objId } = objInfo;
+
+  const url = objId ? `/v1/objective?objectiveId=${objId}` : '/v1/objective';
+  const { mutate } = useSWR(url, getDashBoardData);
 
   const { modalRef, handleShowModal } = useModal();
 
   const [isntFull, setIsntFull] = useState(false);
+
+  const mutateFcn = () => {
+    mutate();
+    setState(state);
+  };
 
   useEffect(() => {
     if (krListLen >= 3) {
@@ -39,7 +50,7 @@ const EditObjectNode = ({ objStroke, objInfo, krListLen }: IEditObjectNode) => {
 
   return (
     <>
-      <AddKrModal modalRef={modalRef} objInfo={objInfo} krIdx={krListLen} />
+      <AddKrModal modalRef={modalRef} objInfo={objInfo} krIdx={krListLen} mutateFcn={mutateFcn} />
       <StNodesContainer>
         <StObjLabel>O</StObjLabel>
         <StObjBoxWrapper>

--- a/src/MainDashBoard/components/editOkrTree/EditTaskNodes.tsx
+++ b/src/MainDashBoard/components/editOkrTree/EditTaskNodes.tsx
@@ -88,6 +88,8 @@ export const EditTaskNodes = ({
   const handleConfirmDelTask = async () => {
     try {
       await deletOkrInstance(`/v1/task/${task.taskId}`);
+      mutate();
+      setState(state);
     } catch {
       navigate('/error');
     }

--- a/src/MainDashBoard/components/editOkrTree/EditTaskNodes.tsx
+++ b/src/MainDashBoard/components/editOkrTree/EditTaskNodes.tsx
@@ -74,8 +74,8 @@ export const EditTaskNodes = ({
     try {
       await postAddTask('/v1/task', {
         keyResultId: editKrId,
-        title: taskValue,
-        idx: taskIdx,
+        taskTitle: taskValue,
+        taskIdx: taskIdx,
       });
       mutate();
       setState(state);

--- a/src/MainDashBoard/components/mainDashBoardOkrTree/MainDashboardOKRTree.tsx
+++ b/src/MainDashBoard/components/mainDashBoardOkrTree/MainDashboardOKRTree.tsx
@@ -106,6 +106,8 @@ const MainDashboardOKRTree = ({ onShowSideSheet, currentOkrData }: IMainDashboar
                       objTitle: currentOkrData?.objTitle,
                     }}
                     krListLen={currentOkrData?.krList.length}
+                    state={state}
+                    setState={setState}
                   />
                 )}
                 keyResultList={editKrList}
@@ -115,6 +117,9 @@ const MainDashboardOKRTree = ({ onShowSideSheet, currentOkrData }: IMainDashboar
                     krList={editKrList[krIdx]}
                     handleAddTask={handleAddTask}
                     krId={editKrList[krIdx].krId}
+                    objId={currentOkrData?.objId}
+                    state={state}
+                    setState={setState}
                   />
                 )}
                 TaskNodes={(isFirstChild, krIdx, taskIdx) => (

--- a/src/MainDashBoard/components/sideSheet/KRPeriodSelect.tsx
+++ b/src/MainDashBoard/components/sideSheet/KRPeriodSelect.tsx
@@ -33,8 +33,8 @@ const KRPeriodSelect = ({
     formatString[0] && formatString[1] ? setPeriod(formatString) : {};
     const data = {
       keyResultId: keyResultId,
-      startAt: formatDate(formatString[0]),
-      expireAt: formatDate(formatString[1]),
+      krStartAt: formatDate(formatString[0]),
+      krExpireAt: formatDate(formatString[1]),
     };
     try {
       await patchCheckIn('/v1/key-result', data);

--- a/src/MainDashBoard/components/sideSheet/KrStatus.tsx
+++ b/src/MainDashBoard/components/sideSheet/KrStatus.tsx
@@ -50,7 +50,7 @@ const KrStatus = ({ krStatus, keyResultId }: { krStatus: string; keyResultId: nu
     setKrStatusLabel(currentStatusLabel);
     const data = {
       keyResultId: keyResultId,
-      state: currentStatusLabel,
+      krState: currentStatusLabel,
     };
 
     try {

--- a/src/MainDashBoard/components/sideSheet/krCheckIn/KrCheckInInputs.tsx
+++ b/src/MainDashBoard/components/sideSheet/krCheckIn/KrCheckInInputs.tsx
@@ -245,7 +245,7 @@ export const KR수정하기 = ({
   const submitCheckIn = async () => {
     const data = {
       keyResultId,
-      target: parseInt(targetValue.replace(/,/g, '')),
+      krTarget: parseInt(targetValue.replace(/,/g, '')),
       logContent,
     };
 

--- a/src/MainDashBoard/type/addKrType.ts
+++ b/src/MainDashBoard/type/addKrType.ts
@@ -1,9 +1,9 @@
 export interface IAddKrType {
   objectiveId: number;
-  title: string;
-  startAt: string;
-  expireAt: string;
-  idx: number;
-  target: number;
-  metric: string;
+  krTitle: string;
+  krStartAt: string;
+  krExpireAt: string;
+  krIdx: number;
+  krTarget: number;
+  krMetric: string;
 }

--- a/src/MainDashBoard/type/addTaskType.ts
+++ b/src/MainDashBoard/type/addTaskType.ts
@@ -1,5 +1,5 @@
 export interface IPostAddTaskType {
   keyResultId: number | undefined;
-  title: string;
-  idx: number;
+  taskTitle: string;
+  taskIdx: number;
 }

--- a/src/MainDashBoard/type/mainReqTypes.ts
+++ b/src/MainDashBoard/type/mainReqTypes.ts
@@ -1,10 +1,10 @@
 export interface IPatchCheckInReqType {
   keyResultId: number;
-  title?: string;
-  startAt?: string;
-  expireAt?: string;
-  target?: number;
-  state?: string;
+  krTitle?: string;
+  krStartAt?: string;
+  krExpireAt?: string;
+  krTarget?: number;
+  krState?: string;
   logContent?: string;
   data?: {
     objId: number;


### PR DESCRIPTION
## 🔥 Related Issues

- close #244

## 💜 작업 내용

- [x] KR 추가 삭제, Task 추가 삭제 관련 API 네이밍 수정 반영 (kr ~ , task~ 형태로 통일)
- [x] 데이터 캐싱 반영(mutate)

## ✅ PR Point

1.  KR 추가 삭제, Task 추가 삭제 관련 API 네이밍 수정 반영 (kr ~ , task~ 형태로 통일)
<img width="869" alt="스크린샷 2024-03-22 11 24 56" src="https://github.com/MOONSHOT-Team/MOONSHOT-CLIENT/assets/77691829/560aecf3-c035-4669-bd55-f09cded65661">
* 보다 나은 유지보수 용이성을 위해 kr, task 관련 api 네이밍 통일을 요청드려서 반영했습니다!
* 에러 없는지 체크는 했는데 @SooY2 수연이 쪽 기능 이상 없는지 더블체크 부탁드려요 ~

3. mutate로 데이터 캐싱 반영
* 기존에는 삭제 모달, 추가 모달에서 kr을 추가,삭제하거나 task를 추가,삭제하면 새로고침 시에만 변동 된 데이터가 반영 되었는데요,
이를 기존 수연이가 적용해 놓은 방식처럼 useSWR의 local mutate function을 사용해 데이터 캐싱을 하여, 변동 된 데이터가 바로 보이도록 반영 해놨습니다.
* task 삭제 모달에서는 props를 여러개 넘기는것보다 mutate 되도록 하는 부분 (mutate (), setState(state)을 하나의 함수로 만들어주고 해당 함수를 넘겨 주었습니당

* 모달 내부 이슈 사항들 (ex. date picker 달력이 dialog 모달 뒤로 나옴. .. ...)은 에러 메시지 적용하면서 새로운 이슈 파서 해결할 예정입니당

## 😡 Trouble Shooting

- 잘 작동 되는지 확인해주세용 ~

## ☀️ 스크린샷 / GIF / 화면 녹화



https://github.com/MOONSHOT-Team/MOONSHOT-CLIENT/assets/77691829/fc4d4ea5-da48-4ec6-8006-174d5ada0d23


