### PR TITLE
[SP1/refactor] KR 추가 모달 뒤로 datepicker 달력 나오는 이슈 해결

### DIFF
--- a/src/AddOkr/components/addKr/KeyResultPeriodInput.tsx
+++ b/src/AddOkr/components/addKr/KeyResultPeriodInput.tsx
@@ -56,6 +56,9 @@ const KeyResultPeriodInput = ({
         }}
       >
         <RangePicker
+          getPopupContainer={(triggerNode: HTMLElement) => {
+            return triggerNode.parentNode?.parentNode as HTMLElement;
+          }}
           variant="borderless"
           onChange={handleClickSelectDate}
           value={[dayjs(formatDate(krPeriod[0])), dayjs(formatDate(krPeriod[1]))]}

--- a/src/AddOkr/components/addKr/KeyResultPeriodInput.tsx
+++ b/src/AddOkr/components/addKr/KeyResultPeriodInput.tsx
@@ -57,6 +57,7 @@ const KeyResultPeriodInput = ({
       >
         <RangePicker
           getPopupContainer={(triggerNode: HTMLElement) => {
+            //datepickker가 항상 상위로 나올수 있도록, 날짜를 선택하는 input과 dom 트리 상 위치를 똑같이 함
             return triggerNode.parentNode?.parentNode as HTMLElement;
           }}
           variant="borderless"

--- a/src/MainDashBoard/components/editModeModal/AddKrModal.tsx
+++ b/src/MainDashBoard/components/editModeModal/AddKrModal.tsx
@@ -163,7 +163,6 @@ const StAddKrModalWrapper = styled.div`
   gap: 3.6rem;
   align-items: center;
 
-  /* justify-content: center; */
   width: 47.6rem;
   height: 47.6rem;
   padding: 3.4rem 3.8rem 3.6rem;

--- a/src/common/components/Modal/index.tsx
+++ b/src/common/components/Modal/index.tsx
@@ -39,6 +39,7 @@ const StModalDialog = styled.dialog`
   left: 50%;
   width: fit-content;
   height: fit-content;
+  overflow: visible;
   background: ${({ theme }) => theme.colors.gray_550};
   border: none;
   border-radius: 10px;

--- a/src/common/components/Modal/index.tsx
+++ b/src/common/components/Modal/index.tsx
@@ -39,7 +39,7 @@ const StModalDialog = styled.dialog`
   left: 50%;
   width: fit-content;
   height: fit-content;
-  overflow: visible;
+  overflow: visible; /* dialog 위로 datepicker 달력 나올수 있도록 수정 */
   background: ${({ theme }) => theme.colors.gray_550};
   border: none;
   border-radius: 10px;


### PR DESCRIPTION
## 🔥 Related Issues

- close #251 

## 💜 작업 내용

- [x] KR 추가 모달 뒤로 datepicker 달력 나오는 이슈 해결


## ✅ PR Point
저를 괴롭히던 kr 추가 모달에서의 datepicker 이슈를 해결했습니다...

### 1) antd DatePicker(RangePicker)의 getPopupContainer
<img width="939" alt="image" src="https://github.com/MOONSHOT-Team/MOONSHOT-CLIENT/assets/77691829/4ede86e8-54c2-4b41-b86b-a11343033cdc">

* 저희가 사용하던 antd의 datepicker(rangepicker)는 `gepopupContainer`라는 속성이 있는데요, 이걸로 달력 팝업이 dom의 어느 계층에 위치할 수 조정할 수 있었습니다!
* 달력 팝업이 모달 뒤로 나왔던 이유는 저희가 모달을 `dialog`라는 태그로 구현했고, 해당 태그는 태그 자체적인 position과 z-index 값을 가지게 됩니다.
* 따라서 backdrop 위로, position: fixed 값을 가지는 모달 내부에 있는 태그들(달력 팝업을 나타나게 하는 트리거인 periodInput)과 똑같이 달력 팝업의 계층을 getPopupContianer로 설정 해두었더니 달력이 모달 위로 위치 했습니다.

### 2) dialog modal overflow : visible
<img width="690" alt="image" src="https://github.com/MOONSHOT-Team/MOONSHOT-CLIENT/assets/77691829/eee69df9-c539-4dc0-84ca-ebbce874d01c">

* 그러나 여전히 위처럼 달력 팝업 전체가 아닌 잘려서 보이는 이슈가 있었습니다.
* 진짜 별 방법을 다 해봤는데,, 잘려서 보이거나 아니면 모달 내부에 스크롤이 생기던가 등의 문제점이 지속적으로 있었습니다. 그러다 계속 모달부분에 overflow: hidden 속성이 있는걸 발견 했는데요 ..! 그래서 모달 공통 컴포넌트의 dialog 태그에 overflow: visible을 주니 잘린 부분이 나타났습니다! ˗ˋˏ와ˎˊ˗ ‼️ !!! 


## 😡 Trouble Shooting

- 원래 z-index로 해결하려고 쌓임 맥락에 대해 좀 알아 봤었는데 z-index 문제는 아니더라구요. 근데 z-index 쌓임 맥락에 대한 [이 자료](https://erwinousy.medium.com/z-index%EA%B0%80-%EB%8F%99%EC%9E%91%ED%95%98%EC%A7%80%EC%95%8A%EB%8A%94-%EC%9D%B4%EC%9C%A0-4%EA%B0%80%EC%A7%80-%EA%B7%B8%EB%A6%AC%EA%B3%A0-%EA%B3%A0%EC%B9%98%EB%8A%94-%EB%B0%A9%EB%B2%95-d5097572b82f)를 같이 공유하고 싶어 남깁니다! z-index가 왜 안먹히는지에 대한 설명이 자세히 나와 있어 좋아유

## ☀️ 스크린샷 / GIF / 화면 녹화
<img width="951" alt="image" src="https://github.com/MOONSHOT-Team/MOONSHOT-CLIENT/assets/77691829/52801aad-3dbf-4a08-8fe3-9762f1589310">

