### PR TITLE
[SP1/refactor] dynamic input 사용성 개선

### DIFF
--- a/src/common/components/input/DynamicInput.tsx
+++ b/src/common/components/input/DynamicInput.tsx
@@ -1,11 +1,10 @@
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef } from 'react';
 
 interface IDynamicInputProps {
   value?: string;
   handleChangeValue: (e: React.ChangeEvent<HTMLInputElement>) => void;
-  minWidth?: number;
   maxLength?: number;
   isAutoFocus?: boolean;
   onKeyDown?: (e: React.KeyboardEvent<HTMLInputElement>) => void;
@@ -14,25 +13,13 @@ interface IDynamicInputProps {
 const DynamicInput = ({
   value,
   handleChangeValue,
-  minWidth,
   maxLength,
   isAutoFocus = false,
   onKeyDown,
 }: IDynamicInputProps) => {
-  const [width, setWidth] = useState(minWidth ? minWidth : 10);
-
-  const mirrorRef = useRef<HTMLInputElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
-    if (!mirrorRef.current) return;
-    setWidth(mirrorRef.current.offsetWidth);
-  }, [value]);
-
-  useEffect(() => {
-    if (!mirrorRef.current) return;
-    setWidth(mirrorRef.current.offsetWidth);
-
     if (!isAutoFocus) return;
     if (inputRef.current) inputRef.current.focus();
   }, [isAutoFocus]);
@@ -41,7 +28,6 @@ const DynamicInput = ({
     <div css={dynamicInputContainerStyle}>
       <StDynamicInput
         type="text"
-        $width={width}
         value={value}
         onChange={handleChangeValue}
         ref={inputRef}
@@ -50,10 +36,9 @@ const DynamicInput = ({
           e.stopPropagation();
           onKeyDown?.(e);
         }}
+        size={1}
       />
-      <StInputMirror ref={mirrorRef} aria-hidden>
-        {value}
-      </StInputMirror>
+      <StInputMirror aria-hidden>{value}</StInputMirror>
     </div>
   );
 };
@@ -61,13 +46,11 @@ const DynamicInput = ({
 export default DynamicInput;
 
 const dynamicInputContainerStyle = css`
-  display: flex;
-  flex-direction: column;
+  display: table;
 `;
 
-const StDynamicInput = styled.input<{ $width: number }>`
-  width: ${({ $width }) => $width / 10}rem;
-  min-width: 1rem;
+const StDynamicInput = styled.input`
+  width: 100%;
   color: ${({ theme }) => theme.colors.gray_000};
   text-align: center;
   background-color: transparent;
@@ -87,7 +70,7 @@ const StDynamicInput = styled.input<{ $width: number }>`
 `;
 
 const StInputMirror = styled.div`
-  display: inline-block;
+  display: block;
   width: fit-content;
   min-width: 1rem;
   height: 0;


### PR DESCRIPTION
## 🔥 Related Issues

- close #259 

## 💜 작업 내용

- [x] dynamic input 깜빡임 현상 개선

## ✅ PR Point
### 📌 개선 내용
* dynamic input (preview Okr, edit Okr Tree에서 쓰이는, 입력에 따라 길이가 유동적으로 늘어나는 input)에서, input에 입력 할 때 input의 길이가 변하면서 유저가 깜빡이는것처럼 인지하게 된다는 내부 UT 사항을 보완했습니다.
<img width="821" alt="image" src="https://github.com/MOONSHOT-Team/MOONSHOT-CLIENT/assets/77691829/164320c1-36ff-4d1d-9c8a-22ad8377c428">

### 📌 원인
* 기존 구현 방식 : input은 원래 고정 넓이를 가지기 때문에 css trick + state에 width 값 저장 방식으로 auto resizing되는 dynamic input 컴포넌트를 구현했습니다. 더 자세히 설명하자면, input에 입력된 text를 보이지 않도록 숨김 처리한 div 태그에 저장 해두고, 이 div 태그의 width 값 (fit-content 한 값)을 width 라는 state에 저장한 다음, 이 width 값을 스타일드 컴포넌트의 prop으로 넘겨주어 입력 된 텍스트에 길이에 따라 input 넓이가 유동적으로 변할수 있게 하였습니다.
* 다만 width 값을 state으로 저장후, 반영하다 보니 state로 저장한 width 값이 변할 때마다 input이 마치 깜빡이는 것처럼 보였던것 같습니다.

### 📌 해결
* 따라서 변하는 width 값을 state으로 저장하는 방식이 아닌, css trick만을 활용한 방식으로 업데이트 했습니다. input은 width 100%로 두고, 상위 태그에 따라서 100%의 값이 바뀌도록 설정해두었습니다.

## 😡 Trouble Shooting


## ☀️ 스크린샷 / GIF / 화면 녹화
* 기존 구현 방식

https://github.com/MOONSHOT-Team/MOONSHOT-CLIENT/assets/77691829/e2ddb570-effa-4399-a2e4-48d198e6ee24


* 현재 개선 방식

https://github.com/MOONSHOT-Team/MOONSHOT-CLIENT/assets/77691829/985cfdc6-53a9-4c76-871f-09dc66d7c5be


## 📚 Reference

- https://www.youtube.com/watch?v=xVATCU9UlFY