### PR TITLE
[Sp1/refactor] mainDashboard 리팩토링 1순위 구현

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -46,7 +46,8 @@ module.exports = {
     'react-hooks/exhaustive-deps': 'warn',
     'simple-import-sort/imports': 'error',
     'simple-import-sort/exports': 'error',
-    'react/no-unknown-property': ['error', { ignore: ['css'], argsIgnorePattern: ['^_'] }],
+    'react/no-unknown-property': ['error', { ignore: ['css'] }],
+    '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
   },
   settings: {
     'import/parsers': {

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -46,7 +46,7 @@ module.exports = {
     'react-hooks/exhaustive-deps': 'warn',
     'simple-import-sort/imports': 'error',
     'simple-import-sort/exports': 'error',
-    'react/no-unknown-property': ['error', { ignore: ['css'] }],
+    'react/no-unknown-property': ['error', { ignore: ['css'], argsIgnorePattern: '^_' }],
   },
   settings: {
     'import/parsers': {

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -46,7 +46,7 @@ module.exports = {
     'react-hooks/exhaustive-deps': 'warn',
     'simple-import-sort/imports': 'error',
     'simple-import-sort/exports': 'error',
-    'react/no-unknown-property': ['error', { ignore: ['css'], argsIgnorePattern: '^_' }],
+    'react/no-unknown-property': ['error', { ignore: ['css'], argsIgnorePattern: ['^_'] }],
   },
   settings: {
     'import/parsers': {

--- a/src/MainDashBoard/apis/fetcher.ts
+++ b/src/MainDashBoard/apis/fetcher.ts
@@ -6,7 +6,8 @@ import { IPatchGoalIdxReqType } from '../type/goalItemTypes';
 import { IPatchCheckInReqType } from '../type/mainReqTypes';
 import { IPostLogResType } from '../type/mainResTypes';
 
-export const getDashBoardData = async (url: string) => {
+export const getDashBoardData = async ([url, _uniqueKey]: [string, string?]) => {
+  console.log(url, _uniqueKey);
   const response = await instance.get(url);
   return response.data;
 };

--- a/src/MainDashBoard/apis/fetcher.ts
+++ b/src/MainDashBoard/apis/fetcher.ts
@@ -7,7 +7,6 @@ import { IPatchCheckInReqType } from '../type/mainReqTypes';
 import { IPostLogResType } from '../type/mainResTypes';
 
 export const getDashBoardData = async ([url, _uniqueKey]: [string, string?]) => {
-  console.log(url, _uniqueKey);
   const response = await instance.get(url);
   return response.data;
 };

--- a/src/MainDashBoard/components/editOkrTree/EditKrNodes.tsx
+++ b/src/MainDashBoard/components/editOkrTree/EditKrNodes.tsx
@@ -38,7 +38,7 @@ export const EditKrNodes = ({
   const navigate = useNavigate();
 
   const url = objId ? `/v1/objective?objectiveId=${objId}` : '/v1/objective';
-  const { mutate } = useSWR(url, getDashBoardData);
+  const { mutate } = useSWR([url, 'MAINDASH'], getDashBoardData);
 
   const { modalRef, handleShowModal } = useModal();
 
@@ -56,14 +56,7 @@ export const EditKrNodes = ({
   };
 
   useEffect(() => {
-    if (krList.taskList.length >= 3) {
-      setIsntFull(false);
-      return;
-    }
-    if (krList.taskList.length < 3) {
-      setIsntFull(true);
-      return;
-    }
+    krList.taskList.length < 3 ? setIsntFull(true) : setIsntFull(false);
   }, [krList]);
 
   if (!krList) return;

--- a/src/MainDashBoard/components/editOkrTree/EditObjectNode.tsx
+++ b/src/MainDashBoard/components/editOkrTree/EditObjectNode.tsx
@@ -33,7 +33,7 @@ const EditObjectNode = ({
   const { objTitle, objId } = objInfo;
 
   const url = objId ? `/v1/objective?objectiveId=${objId}` : '/v1/objective';
-  const { mutate } = useSWR(url, getDashBoardData);
+  const { mutate } = useSWR([url, 'MAINDASH'], getDashBoardData);
 
   const { modalRef, handleShowModal } = useModal();
 

--- a/src/MainDashBoard/components/editOkrTree/EditTaskNodes.tsx
+++ b/src/MainDashBoard/components/editOkrTree/EditTaskNodes.tsx
@@ -47,7 +47,7 @@ export const EditTaskNodes = ({
   const navigate = useNavigate();
 
   const url = objId ? `/v1/objective?objectiveId=${objId}` : '/v1/objective';
-  const { mutate } = useSWR(url, getDashBoardData);
+  const { mutate } = useSWR([url, 'MAINDASH'], getDashBoardData);
 
   const { modalRef, handleShowModal } = useModal();
 

--- a/src/MainDashBoard/components/mainDashBoardDrawer/GoalItem.tsx
+++ b/src/MainDashBoard/components/mainDashBoardDrawer/GoalItem.tsx
@@ -114,10 +114,10 @@ const GoalItem: React.FC<IGoalItemProps> = ({
   });
 
   drag(drop(ref));
-
+  console.log(currentGoalId, id);
   return (
     <StGoalItemLi
-      bgColor={currentGoalId === id}
+      bgColor={currentGoalId === id || currentGoalId === undefined}
       onClick={handleOnClick}
       ref={ref}
       isDragging={isDragging}
@@ -143,7 +143,9 @@ const GoalItem: React.FC<IGoalItemProps> = ({
           <StGoalItemTitle>{title}</StGoalItemTitle>
           <i>{currentGoalId === id ? <IcDropUp /> : <IcDropDown />}</i>
         </article>
-        {currentGoalId === id && <StGoalItemContent>{content}</StGoalItemContent>}
+        {(currentGoalId === id || currentGoalId === undefined) && (
+          <StGoalItemContent>{content}</StGoalItemContent>
+        )}
       </StGoalItemContainer>
       <footer css={ProgressBarContainer}>
         <MainDashProgressBar

--- a/src/MainDashBoard/components/mainDashBoardOkrTree/MainDashboardOKRTree.tsx
+++ b/src/MainDashBoard/components/mainDashBoardOkrTree/MainDashboardOKRTree.tsx
@@ -29,7 +29,6 @@ const MainDashboardOKRTree = ({ onShowSideSheet, currentOkrData }: IMainDashboar
   const url = currentOkrData?.objId
     ? `/v1/objective?objectiveId=${currentOkrData?.objId}`
     : '/v1/objective';
-  console.log(url, 'mainDash');
   const { data } = useSWR([url, 'MAINDASH'], getDashBoardData);
 
   useEffect(() => {

--- a/src/MainDashBoard/components/mainDashBoardOkrTree/MainDashboardOKRTree.tsx
+++ b/src/MainDashBoard/components/mainDashBoardOkrTree/MainDashboardOKRTree.tsx
@@ -29,7 +29,8 @@ const MainDashboardOKRTree = ({ onShowSideSheet, currentOkrData }: IMainDashboar
   const url = currentOkrData?.objId
     ? `/v1/objective?objectiveId=${currentOkrData?.objId}`
     : '/v1/objective';
-  const { data } = useSWR(url, getDashBoardData);
+  console.log(url, 'mainDash');
+  const { data } = useSWR([url, 'MAINDASH'], getDashBoardData);
 
   useEffect(() => {
     setViewMode(OKR_TREE_VIEWS['VIEWOKRTREE']);
@@ -70,11 +71,11 @@ const MainDashboardOKRTree = ({ onShowSideSheet, currentOkrData }: IMainDashboar
                 ObjNode={() => (
                   <MainDashObjectNode objValue={currentOkrData?.objTitle} objStroke="#7165CA" />
                 )}
-                keyResultList={currentOkrData?.krList}
+                keyResultList={editKrList}
                 KrNodes={(krIdx) => (
                   <MainDashKrNodes
                     krIdx={krIdx}
-                    krList={currentOkrData?.krList[krIdx]}
+                    krList={editKrList[krIdx]}
                     onShowSideSheet={onShowSideSheet}
                   />
                 )}
@@ -82,7 +83,7 @@ const MainDashboardOKRTree = ({ onShowSideSheet, currentOkrData }: IMainDashboar
                   <MainDashTaskNodes
                     isFirstChild={isFirstChild}
                     taskIdx={taskIdx}
-                    taskList={currentOkrData?.krList[krIdx]?.taskList}
+                    taskList={editKrList[krIdx]?.taskList}
                   />
                 )}
               />

--- a/src/MainDashBoard/components/sideSheet/SideSheet.tsx
+++ b/src/MainDashBoard/components/sideSheet/SideSheet.tsx
@@ -31,7 +31,7 @@ const SideSheet = ({
   onClose,
   handleChangeState,
 }: ISideSheetProps) => {
-  const { data: sideSheetData } = useSWR(`/v1/key-result/${keyResultId}`, getDashBoardData);
+  const { data: sideSheetData } = useSWR([`/v1/key-result/${keyResultId}`], getDashBoardData);
   const krDetailData = sideSheetData?.data;
   const modalRef = useRef<HTMLDivElement>(null);
 

--- a/src/MainDashBoard/index.tsx
+++ b/src/MainDashBoard/index.tsx
@@ -57,7 +57,7 @@ const MainDashBoard = () => {
 
   //동적 파라미터 url
   const url = currentGoalId ? `/v1/objective?objectiveId=${currentGoalId}` : '/v1/objective';
-  const { data: treeData, isLoading, mutate } = useSWR(url, getDashBoardData);
+  const { data: treeData, isLoading, mutate } = useSWR([url, 'index'], getDashBoardData);
   const okrTreeData = treeData?.data.tree;
   const goalListTreeData = treeData?.data.objList;
 

--- a/src/common/components/okrTree/template/krTemplate/KrContainer.tsx
+++ b/src/common/components/okrTree/template/krTemplate/KrContainer.tsx
@@ -14,7 +14,7 @@ interface IKrContainerProps {
 const KrContainer = ({ keyResultList, KrNodes, TaskNodes }: IKrContainerProps) => {
   return (
     <StKrContainer>
-      {keyResultList.map((kr) => {
+      {keyResultList?.map((kr) => {
         return (
           <StKrWrapper key={`$ya{kr.keyResultTitle}-${kr.krIdx}`}>
             <NodeLines />


### PR DESCRIPTION
## 🔥 Related Issues

- close #219 

## 💜 작업 내용

- [x] edit에서 추가/삭제 시 view모드로 이동하는 이슈
- [x] 처음 okr생성 시 드롭다운 안되어있는 이슈

## ✅ PR Point
### eslint 언더스코어 허용
fetcher을 수정하면서 언더스코어를 사용해야했습니다! 근데 eslint때문에 걸리더라구요..
``` typescript
export const getDashBoardData = async ([url, _uniqueKey]: [string, string?]) => {
  const response = await instance.get(url);
  return response.data;
};
```
eslintrc.cjs 파일의 rules에 예외를 추가해주었습니다!
```
'@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
```

### 처음 생성시 드롭다운
처음 생성이라 서버에 요청한는 objId가 undefined라서 나는 이슈였습니다! 그래서 undefined라면 선택이 되도록 수정해주었습니다!


## 😡 Trouble Shooting

### edit에서 추가/삭제 시 view모드로 이동하는 이슈
mutate.. 이자식이 문제였습니다

**♻️ edit모드를 구현했던 방법**
index.tsx > MainDashboardOKRTree.tsx 구조로 이루어져 있고, 두 파일에서 `/v1/objective?objectiveId=${currentGoalId}` or `/v1/objective` 로 api요청을 합니다. 
두군데에서 하는 이유는 `index.tsx` 파일에선 drawer와 최근의 okr을 받아오기 위함이고, `MainDashboardOKRTree.tsx` 에선 edit뷰에서 수정을 했을 때, 재렌더링이 되지 않으면서(editview를 유지하면서) 추가된 okrTree의 정보를 바로 받아오고 싶었기 때문입니다!!

**♻️ mutate**
 추가/삭제를 할 때 `mutate()`로 재검증을 해주었는데, **mutate는 key값이 같은 요청을 재검증**합니다. 이 때, 위에서 제가 두 곳에 같은 url(key)로 요청을 했기 때문에 `MainDashboardOKRTree.tsx` 파일과 `index.tsx`파일에 있는 swr을 재검증 하게됩니다.
 따라서 `index.tsx` 파일에선 재렌더링 되었을 때 mode를 view로 바꾸는 코드가 있기 때문에 view모드로 돌아가는 것이였습니다😇
 
 _📎 제가 카톡방에 "edit/view 모드 변경이 처음 새로고침한 okr은 edit뷰에서 잘 머무는데 drawer에서 클릭해서 들어간 okr이 문제인 점 발견해서 이유 찾고있는데... " 라고 남겼었는데요! 처음 새로고침했을 때의 key값은 `/v1/objective`이기 때문에 `MainDashboardOKRTree.tsx`의  `/v1/objective?objectiveId=${currentGoalId}` key값이 달라 잘 되는 것이였습니당_

**⚽️ 해결방법**
**두개의 swr에 다른 고유한 key값을 부여해주자** 
`useSWR([url, 'index'], getDashBoardData);` , `useSWR([url, 'MAINDASH'], getDashBoardData);`  이렇게 index와 MAINDASH로 key 값을 부여해서 `MAINDASH`의 재검증이 필요한 부분에선 
`const { mutate } = useSWR([url, 'MAINDASH'], getDashBoardData);` 이런식으로 각 key값의 swr요청을 불러오는 방식으로 해결했습니당!!!

## ☀️ 스크린샷 / GIF / 화면 녹화

https://github.com/MOONSHOT-Team/MOONSHOT-CLIENT/assets/101343915/ce8366c4-8d99-4662-9f72-069be046c71f


## 📚 Reference


