### PR TITLE
[SP2/refacor] AddOkr : addOkr objTitleCateg 관련 개선 사항 반영

### DIFF
--- a/src/AddOkr/components/stepLayout/ObjTitleCateg.tsx
+++ b/src/AddOkr/components/stepLayout/ObjTitleCateg.tsx
@@ -28,6 +28,14 @@ const ObjTitleCateg = ({ isGuide, objInfo, setObjInfo }: IObjTitleCategProps) =>
   **/
   // 카테고리 태그 선택 핸들러
   const handleClickObjCateg = (e: React.MouseEvent<HTMLButtonElement>) => {
+    const currSelectedCateg = e.currentTarget.id;
+
+    // 카테고리 재선택시 취소
+    if (currSelectedCateg === selectedObjCateg) {
+      setObjInfo({ ...objInfo, objCategory: '' });
+      return;
+    }
+
     setObjInfo({ ...objInfo, objCategory: e.currentTarget.id });
   };
 

--- a/src/AddOkr/components/stepLayout/ObjTitleCateg.tsx
+++ b/src/AddOkr/components/stepLayout/ObjTitleCateg.tsx
@@ -62,9 +62,14 @@ const ObjTitleCateg = ({ isGuide, objInfo, setObjInfo }: IObjTitleCategProps) =>
     setHoverObjPlaceHolder(targetPlaceholder);
   };
 
-  // 이미 선택된 obj가 있을때, mouseleave시 선택 된 obj의 placeholder로 유지되도록
   const handleMouseLeaveObjCateg = () => {
-    if (!selectedObjCateg) return;
+    // 선택 취소 or 선택된 obj가 없을때, mouseleave 시 기본 placeholder 보여주도록
+    if (!selectedObjCateg) {
+      setHoverObjPlaceHolder(GUIDE_DEFAULT_PLACEHOLDER);
+      return;
+    }
+
+    // 이미 선택된 obj가 있을때, mouseleave시 선택 된 obj의 placeholder로 유지되도록
     const { placeholder: targetPlaceholder } = GUIDE_OBJ_TITLE_PLACEHOLDER.filter(
       (tag) => tag.id === selectedObjCateg,
     )[0];


### PR DESCRIPTION
## 🔥 Related Issues

- close #275 

## 💜 작업 내용

- [x] 테마 재선택 시 실행 취소 고려 필요
- [x] 선택 된 테마 없을 때, 미호버 시 디폴트값인 목표를 입력하세요로 변경될 필요 (일관성 유지)

## ✅ PR Point
1. 취소 로직 추가
```js
  // 카테고리 태그 선택 핸들러
  const handleClickObjCateg = (e: React.MouseEvent<HTMLButtonElement>) => {
    const currSelectedCateg = e.currentTarget.id;

    // 카테고리 재선택시 취소
    if (currSelectedCateg === selectedObjCateg) {
      setObjInfo({ ...objInfo, objCategory: '' });
      return;
    }

    setObjInfo({ ...objInfo, objCategory: e.currentTarget.id });
  };
```

2. 취소 로직 추가에 따라 -> 카테고리 미선택시 호버 빠지면 기본 placeholder 노출
```js

  const handleMouseLeaveObjCateg = () => {
    // 선택 취소 or 선택된 obj가 없을때, mouseleave 시 기본 placeholder 보여주도록
    if (!selectedObjCateg) {
      setHoverObjPlaceHolder(GUIDE_DEFAULT_PLACEHOLDER);
      return;
    }

    // 이미 선택된 obj가 있을때, mouseleave시 선택 된 obj의 placeholder로 유지되도록
    const { placeholder: targetPlaceholder } = GUIDE_OBJ_TITLE_PLACEHOLDER.filter(
      (tag) => tag.id === selectedObjCateg,
    )[0];
```

## 😡 Trouble Shooting

- x

## ☀️ 스크린샷 / GIF / 화면 녹화

https://github.com/MOONSHOT-Team/MOONSHOT-CLIENT/assets/77691829/91d06754-bb2e-4100-81fa-8e645ce67346


