### PR TITLE
[SP2/Feat] 랜딩페이지 유저 플로우 변경

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -16,7 +16,6 @@ const MainLayout = lazy(() => import('@components/Layout/MainLayout'));
 const My = lazy(() => import('./My'));
 const Nickname = lazy(() => import('./Nickname'));
 const TeamMoonshot = lazy(() => import('./Onboarding/components/teamMoonshot/TeamMoonshot'));
-// const PreviewOkr = lazy(() => import('./PreviewOkr'));
 const SignIn = lazy(() => import('./SignIn'));
 const Social = lazy(() => import('./Social'));
 
@@ -60,17 +59,9 @@ const router = createBrowserRouter([
         path: 'social',
         element: <Social />,
       },
-      // {
-      //   path: 'preview-okr',
-      //   element: <PreviewOkr />,
-      // },
       {
         path: 'dashboard',
         element: <MainDashBoard />,
-      },
-      {
-        path: 'add-okr',
-        element: <AddOkr />,
       },
       {
         path: 'add-okr',

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -1,5 +1,5 @@
-import { lazy } from 'react';
-import { createBrowserRouter } from 'react-router-dom';
+import { lazy, useEffect } from 'react';
+import { createBrowserRouter, useNavigate } from 'react-router-dom';
 
 import Onboarding from './Onboarding';
 import OnboardingLayout from './Onboarding/components/layout/OnboardingLayout';
@@ -20,27 +20,27 @@ const TeamMoonshot = lazy(() => import('./Onboarding/components/teamMoonshot/Tea
 const SignIn = lazy(() => import('./SignIn'));
 const Social = lazy(() => import('./Social'));
 
+const RoutingHomePage = () => {
+  const isLoggedIn = localStorage.getItem('ACCESS_TOKEN') != undefined;
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    localStorage.getItem('ACCESS_TOKEN') != undefined ? navigate('/dashboard') : navigate('/about');
+  }, [isLoggedIn, navigate]);
+
+  return <></>;
+};
+
 const router = createBrowserRouter([
-  {
-    path: '/',
-    element: <OnboardingLayout />,
-    errorElement: <Error />,
-    children: [
-      {
-        index: true,
-        element: <Onboarding />,
-      },
-      {
-        path: 'team-moonshot',
-        element: <TeamMoonshot />,
-      },
-    ],
-  },
   {
     path: '/',
     element: <MainLayout />,
     errorElement: <Error />,
     children: [
+      {
+        index: true,
+        element: <RoutingHomePage />,
+      },
       {
         path: 'history',
         element: <History />,
@@ -83,6 +83,21 @@ const router = createBrowserRouter([
       {
         path: 'error',
         element: <Error />,
+      },
+    ],
+  },
+  {
+    path: '/about',
+    element: <OnboardingLayout />,
+    errorElement: <Error />,
+    children: [
+      {
+        index: true,
+        element: <Onboarding />,
+      },
+      {
+        path: 'team-moonshot',
+        element: <TeamMoonshot />,
       },
     ],
   },


### PR DESCRIPTION
## 🔥 Related Issues

- close #274 

## 💜 작업 내용

- [x] 로그인 여부에 따른 페이지 라우팅

## ✅ PR Point

- / 에 해당하는 페이지를 렌더링 하는 컴포넌트를 따로 분리하지 않고 Router.tsx에 넣었습니다.
```jsx
const RoutingHomePage = () => {
  const isLoggedIn = localStorage.getItem('ACCESS_TOKEN') != undefined;
  const navigate = useNavigate();

  useEffect(() => {
    localStorage.getItem('ACCESS_TOKEN') != undefined ? navigate('/dashboard') : navigate('/about');
  }, [isLoggedIn, navigate]);

  return <></>;
};
```

이유로는 코드가 길지도 않고 이를 나눠서 관리할 필요가 없다고 생각했습니다.
물론 Router.tsx에 router 기능만 넣고 싶기도 했는데, 파일 분리하는 게 더 관리하기 불편해질 거 같다고 판단하여 그러진 않았습니다.
이에 대해 분리를 원하시다면 편하게 얘기해 주세요!
