### PR TITLE
[SP2/feat] 클릭된 KR활성화 디자인

### DIFF
--- a/src/MainDashBoard/components/mainDashBoardOkrTree/MainDashKrNodes.tsx
+++ b/src/MainDashBoard/components/mainDashBoardOkrTree/MainDashKrNodes.tsx
@@ -60,6 +60,8 @@ const StMainDashBox = styled(StKrBox)<{ isActive: boolean }>`
   cursor: pointer;
   background-color: ${({ theme, isActive }) =>
     isActive ? theme.colors.transparent_purple : theme.colors.gray_600};
+  outline-color: ${({ theme, isActive }) =>
+    isActive ? theme.colors.main_darkpurple : theme.colors.gray_500};
 
   ${({ theme }) => theme.fonts.body_13_medium};
 `;

--- a/src/MainDashBoard/components/mainDashBoardOkrTree/MainDashKrNodes.tsx
+++ b/src/MainDashBoard/components/mainDashBoardOkrTree/MainDashKrNodes.tsx
@@ -14,9 +14,15 @@ interface IMainDashKrNodesProps {
   krIdx: number;
   krList: IKeyResultTypes;
   onShowSideSheet: (krId: number | undefined) => void;
+  currentKrId: number;
 }
 
-export const MainDashKrNodes = ({ krIdx, krList, onShowSideSheet }: IMainDashKrNodesProps) => {
+export const MainDashKrNodes = ({
+  krIdx,
+  krList,
+  onShowSideSheet,
+  currentKrId,
+}: IMainDashKrNodesProps) => {
   if (!krList) return;
   const { krTitle, krId } = krList;
 
@@ -27,6 +33,7 @@ export const MainDashKrNodes = ({ krIdx, krList, onShowSideSheet }: IMainDashKrN
         <StraightLine />
         <StyledIcDrag />
         <StMainDashBox
+          isActive={currentKrId === krId}
           onClick={() => {
             onShowSideSheet(krId);
           }}
@@ -48,9 +55,11 @@ const StyledIcDrag = styled(IcDrag)`
   margin: 0 0.5rem 0 0.6rem;
 `;
 
-const StMainDashBox = styled(StKrBox)`
+const StMainDashBox = styled(StKrBox)<{ isActive: boolean }>`
   color: ${({ theme }) => theme.colors.gray_000};
   cursor: pointer;
+  background-color: ${({ theme, isActive }) =>
+    isActive ? theme.colors.transparent_purple : '#242424'};
 
   ${({ theme }) => theme.fonts.body_13_medium};
 `;

--- a/src/MainDashBoard/components/mainDashBoardOkrTree/MainDashKrNodes.tsx
+++ b/src/MainDashBoard/components/mainDashBoardOkrTree/MainDashKrNodes.tsx
@@ -59,7 +59,7 @@ const StMainDashBox = styled(StKrBox)<{ isActive: boolean }>`
   color: ${({ theme }) => theme.colors.gray_000};
   cursor: pointer;
   background-color: ${({ theme, isActive }) =>
-    isActive ? theme.colors.transparent_purple : '#242424'};
+    isActive ? theme.colors.transparent_purple : theme.colors.gray_600};
 
   ${({ theme }) => theme.fonts.body_13_medium};
 `;

--- a/src/MainDashBoard/components/mainDashBoardOkrTree/MainDashboardOKRTree.tsx
+++ b/src/MainDashBoard/components/mainDashBoardOkrTree/MainDashboardOKRTree.tsx
@@ -21,9 +21,14 @@ import { MainDashTaskNodes } from './MainDashTaskNodes';
 interface IMainDashboardOKRTreeProps {
   currentOkrData: IMainData;
   onShowSideSheet: (krId: number | undefined) => void;
+  currentKrId: number;
 }
 
-const MainDashboardOKRTree = ({ onShowSideSheet, currentOkrData }: IMainDashboardOKRTreeProps) => {
+const MainDashboardOKRTree = ({
+  onShowSideSheet,
+  currentOkrData,
+  currentKrId,
+}: IMainDashboardOKRTreeProps) => {
   const [viewMode, setViewMode] = useState(OKR_TREE_VIEWS['VIEWOKRTREE']);
   const [editKrId, setEditKrId] = useState<number | undefined>();
   const [editKrList, setEditKrList] = useState<IKeyResultTypes[]>(currentOkrData?.krList);
@@ -77,6 +82,7 @@ const MainDashboardOKRTree = ({ onShowSideSheet, currentOkrData }: IMainDashboar
                     krIdx={krIdx}
                     krList={editKrList[krIdx]}
                     onShowSideSheet={onShowSideSheet}
+                    currentKrId={currentKrId}
                   />
                 )}
                 TaskNodes={(isFirstChild, krIdx, taskIdx) => (

--- a/src/MainDashBoard/index.tsx
+++ b/src/MainDashBoard/index.tsx
@@ -131,6 +131,7 @@ const MainDashBoard = () => {
 
   const handleCloseSideSheet = () => {
     setShowSideSheet(false);
+    setCurrentKrId(-1);
   };
 
   /** 

--- a/src/MainDashBoard/index.tsx
+++ b/src/MainDashBoard/index.tsx
@@ -38,7 +38,7 @@ const MainDashBoard = () => {
 
   const [showSideSheet, setShowSideSheet] = useState<boolean>(false);
   const [currentGoalId, setCurrentGoalId] = useState<number>();
-  const [currentKrId, setCurrentKrId] = useState<number>(0);
+  const [currentKrId, setCurrentKrId] = useState<number>(-1);
 
   const [showState, setShowState] = useState(DASHBOARD_SHOW_STATE[0]);
   const [targetModal, setTargetModal] = useState<string | null>(null);
@@ -86,7 +86,7 @@ const MainDashBoard = () => {
     setShowState(DASHBOARD_SHOW_STATE[1]);
   };
 
-  const handleCurrentGoalId = (id: number | number) => {
+  const handleCurrentGoalId = (id: number) => {
     if (!id) return;
     setCurrentGoalId(id);
   };
@@ -160,6 +160,7 @@ const MainDashBoard = () => {
               <MainDashboardOKRTree
                 onShowSideSheet={handleShowSideSheet}
                 currentOkrData={okrTreeData}
+                currentKrId={currentKrId}
               />
             </section>
             {showSideSheet && (


### PR DESCRIPTION
## 🔥 Related Issues

- close #280 

## 💜 작업 내용

- [x] 클릭된 KR활성화 디자인

## ✅ PR Point

####  1️⃣ `currentKrId` 로 활성화된 Kr인지 확인
```tsx
    <StMainDashBox
          isActive={currentKrId === krId}
          onClick={() => {
            onShowSideSheet(krId);
          }}
...
```
#### 2️⃣ 사이드시트 닫으면 `currentKrId`값 변경
```tsx
const handleCloseSideSheet = () => {
    setShowSideSheet(false);
    setCurrentKrId(-1);
  };
```
초기 `currentKrId`값을 0으로 했었는데 인덱스가 0부터 시작하기 때문에 혹시 몰라 `-1`로 변경해 주었습니다!


## 😡 Trouble Shooting


## ☀️ 스크린샷 / GIF / 화면 녹화

https://github.com/MOONSHOT-Team/MOONSHOT-CLIENT/assets/101343915/e1db28e0-8bac-4d85-96d3-e355fa325441


## 📚 Reference

- 구현에 참고한 링크 (필요한 경우만 작성하고 없으면 지우기)
