### PR TITLE
[SP2/Feat] 랜딩페이지 우상단 베타서비스 링크 수정

### DIFF
--- a/src/Onboarding/components/frame/Frame1.tsx
+++ b/src/Onboarding/components/frame/Frame1.tsx
@@ -11,6 +11,7 @@ import imgFrame1SideSheetRight from '../../assets/frame/imgFrame1SideSheetRight.
 import webpFrame1MainDashboard from '../../assets/frame/webpFrame1MainDashboard.webp';
 import webpFrame1ObjectiveItem from '../../assets/frame/webpFrame1ObjectiveItem.webp';
 import webpFrame1SideSheetRight from '../../assets/frame/webpFrame1SideSheetRight.webp';
+import { APPLY_CBT_TALLY_LINK } from '../../constants/APPLY_LINK';
 import { CONTENTS } from '../../constants/CONTENTS';
 import { TEXT_ROLLING } from '../../constants/TEXT_ROLLING';
 import { ImgPopUp, popUp } from '../../styles/animation';
@@ -38,8 +39,8 @@ const Frame1 = () => {
         ))}
       </StRollingTextBox>
       <StMainText>{CONTENTS[0].title}</StMainText>
-      <StCtaLink to="https://tally.so/r/n0Ol0N" target="_blank" className="tally-link-button">
-        서비스 신청하기
+      <StCtaLink to={APPLY_CBT_TALLY_LINK} target="_blank" className="tally-link-button">
+        베타테스트 신청
       </StCtaLink>
       <div css={imgContainer}>
         <div css={fixedBackground} />

--- a/src/Onboarding/components/layout/OnboardingHeader.tsx
+++ b/src/Onboarding/components/layout/OnboardingHeader.tsx
@@ -3,6 +3,7 @@ import webpLogo from '@assets/images/webpLogo.webp';
 import styled from '@emotion/styled';
 import { Link, NavLink } from 'react-router-dom';
 
+import { APPLY_CBT_TALLY_LINK } from '../../constants/APPLY_LINK';
 import { NAV_ITEMS } from '../../constants/NAV_ITEMS';
 
 const OnboardingHeader = () => {
@@ -22,8 +23,8 @@ const OnboardingHeader = () => {
             </li>
           ))}
           <li>
-            <StCTALink to="https://tally.so/r/n0Ol0N" target="_blank" className="tally-link-button">
-              서비스 신청하기
+            <StCTALink to={APPLY_CBT_TALLY_LINK} target="_blank" className="tally-link-button">
+              베타테스트 신청
             </StCTALink>
           </li>
         </StNavItem>

--- a/src/Onboarding/constants/APPLY_LINK.ts
+++ b/src/Onboarding/constants/APPLY_LINK.ts
@@ -1,0 +1,5 @@
+//user test 신청 tally 링크
+// export const APPLY_UT_TALLY_LINK = 'https://tally.so/r/w42bVb';
+
+//cbt 신청 tally 링크
+export const APPLY_CBT_TALLY_LINK = 'https://tally.so/r/w42bVb';


### PR DESCRIPTION
## 🔥 Related Issues

- close #286 

## 💜 작업 내용
 - [x] '서비스 신청하기' 버튼과 연결되는 링크를 https://tally.so/r/w42bVb 으로 수정
 - [x] '서비스 신청하기' 버튼의 라벨을 '서비스 신청하기' -> '베타테스트 신청' 으로 수정

## ✅ PR Point
* cbt 진행을 위해 기존 `서비스 신청하기` 버튼의 연결 링크/워딩을 수정했습니다
<img width="197" alt="image" src="https://github.com/MOONSHOT-Team/MOONSHOT-CLIENT/assets/77691829/035fc56b-c124-430c-9aad-f41468815882">

* 온보딩 랜딩페이지의 Frame 1에 있는 버튼도 동일하게 바꿔 줬습니다
<img width="1440" alt="image" src="https://github.com/MOONSHOT-Team/MOONSHOT-CLIENT/assets/77691829/91242e9a-adc5-4d08-a1fd-4a782cfff9e7">

* 추후 변동 가능성을 고려하여 기존 `서비스 신청하기` 버튼과 연결되는 링크는 상수로 빼주었습니다
-> 기존 유저 테스트 tally로 연결되던 링크도 혹시 몰라 상수로 빼두고, 주석 처리 해두었습니다.


## 😡 Trouble Shooting
- x

## ☀️ 스크린샷 / GIF / 화면 녹화

https://github.com/MOONSHOT-Team/MOONSHOT-CLIENT/assets/77691829/13e38447-b1d7-424e-ae02-e8f8ff43c8b3


